### PR TITLE
Add rexml dependency

### DIFF
--- a/twine.gemspec
+++ b/twine.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.4"
   s.add_runtime_dependency('rubyzip', "~> 2.0")
   s.add_runtime_dependency('safe_yaml', "~> 1.0")
+  s.add_runtime_dependency('rexml', "~> 3.1")
   s.add_development_dependency('rake', "~> 13.0")
   s.add_development_dependency('minitest', "~> 5.5")
   s.add_development_dependency('minitest-ci', "~> 3.0")


### PR DESCRIPTION
As discussed in https://github.com/organicmaps/organicmaps/pull/2382, `rexml` is needed on these two files:

>tools/twine/lib/twine/formatters/android.rb
>tools/twine/lib/twine/formatters/tizen.rb

So I added the runtime dependency in `twine.gemspec`