### PR TITLE
Replace Android %s with iOS %@ in generated strings

### DIFF
--- a/lib/twine/formatters/apple.rb
+++ b/lib/twine/formatters/apple.rb
@@ -1,6 +1,8 @@
 module Twine
   module Formatters
     class Apple < Abstract
+      include Twine::Placeholders
+
       def format_name
         'apple'
       end
@@ -84,6 +86,8 @@ module Twine
       end
 
       def format_value(value)
+        # Replace Android's %s with iOS %@
+        value = convert_placeholders_from_android_to_twine(value)
         escape_quotes(value)
       end
 

--- a/lib/twine/formatters/apple_plural.rb
+++ b/lib/twine/formatters/apple_plural.rb
@@ -1,6 +1,8 @@
 module Twine
   module Formatters
     class ApplePlural < Apple
+      include Twine::Placeholders
+
       SUPPORTS_PLURAL = true
 
       def format_name
@@ -42,7 +44,8 @@ module Twine
         result += "#{tab(4)}<key>value</key>\n#{tab(4)}<dict>\n"
         result += "#{tab(6)}<key>NSStringFormatSpecTypeKey</key>\n#{tab(6)}<string>NSStringPluralRuleType</string>\n"
         result += "#{tab(6)}<key>NSStringFormatValueTypeKey</key>\n#{tab(6)}<string>d</string>\n"
-        result += plural_hash.map{|quantity,value| "#{tab(6)}<key>#{quantity}</key>\n#{tab(6)}<string>#{value}</string>"}.join("\n")
+        # Replace Android's %s with iOS %@
+        result += plural_hash.map{|quantity,value| "#{tab(6)}<key>#{quantity}</key>\n#{tab(6)}<string>#{convert_placeholders_from_android_to_twine(value)}</string>"}.join("\n")
         result += "\n#{tab(4)}</dict>\n#{tab(2)}</dict>\n"
       end
 


### PR DESCRIPTION
Generate valid iOS placeholders for strings even if they are incorrect in the strings.txt file