### PR TITLE
Sort plurals forms in CLDR order

### DIFF
--- a/lib/twine/twine_file.rb
+++ b/lib/twine/twine_file.rb
@@ -58,7 +58,7 @@ module Twine
 
     def plural_translation_for_lang(lang)
       if @plural_translations.has_key? lang
-        @plural_translations[lang].dup
+        @plural_translations[lang].dup.sort_by { |key,_| TwineDefinition::PLURAL_KEYS.index(key) }.to_h
       end
     end
 


### PR DESCRIPTION
Instead of alphabetical, sort these in the expect CLDR order zero...other

Only sort when retreiving the values for formatter consumption, this should leave Twine files in their default order.