### PR TITLE
Align Twine indentation

### DIFF
--- a/lib/twine/formatters/android.rb
+++ b/lib/twine/formatters/android.rb
@@ -108,21 +108,25 @@ module Twine
       end
 
       def format_section_header(section)
-        "\t<!-- SECTION: #{section.name} -->"
+        "#{space(4)}<!-- SECTION: #{section.name} -->"
       end
 
       def format_comment(definition, lang)
-        "\t<!-- #{definition.comment.gsub('--', '—')} -->\n" if definition.comment
+        "#{space(4)}<!-- #{definition.comment.gsub('--', '—')} -->\n" if definition.comment
       end
 
       def key_value_pattern
-        "\t<string name=\"%{key}\">%{value}</string>"
+        "#{space(4)}<string name=\"%{key}\">%{value}</string>"
       end
 
       def format_plural_keys(key, plural_hash)
-        result = "\t<plurals name=\"#{key}\">\n"
-        result += plural_hash.map{|quantity,value| "\t#{' ' * 2}<item quantity=\"#{quantity}\">#{escape_value(value)}</item>"}.join("\n")
-        result += "\n\t</plurals>"
+        result = "#{space(4)}<plurals name=\"#{key}\">\n"
+        result += plural_hash.map{|quantity,value| "#{space(8)}<item quantity=\"#{quantity}\">#{escape_value(value)}</item>"}.join("\n")
+        result += "\n#{space(4)}</plurals>"
+      end
+
+      def space(level)
+        ' ' * level
       end
 
       def gsub_unless(text, pattern, replacement)

--- a/lib/twine/formatters/apple_plural.rb
+++ b/lib/twine/formatters/apple_plural.rb
@@ -37,21 +37,21 @@ module Twine
       end
 
       def format_plural_keys(key, plural_hash)
-        result = "#{tab(2)}<key>#{key}</key>\n"
-        result += "#{tab(2)}<dict>\n"
-        result += "#{tab(4)}<key>NSStringLocalizedFormatKey</key>\n"
-        result += "#{tab(4)}<string>\%\#@value@</string>\n"
-        result += "#{tab(4)}<key>value</key>\n"
-        result += "#{tab(4)}<dict>\n"
-        result += "#{tab(6)}<key>NSStringFormatSpecTypeKey</key>\n"
-        result += "#{tab(6)}<string>NSStringPluralRuleType</string>\n"
-        result += "#{tab(6)}<key>NSStringFormatValueTypeKey</key>\n"
-        "#{tab(6)}<string>d</string>\n"
+        result = "\t<key>#{key}</key>\n"
+        result += "\t<dict>\n"
+        result += "\t\t<key>NSStringLocalizedFormatKey</key>\n"
+        result += "\t\t<string>\%\#@value@</string>\n"
+        result += "\t\t<key>value</key>\n"
+        result += "\t\t<dict>\n"
+        result += "\t\t\t<key>NSStringFormatSpecTypeKey</key>\n"
+        result += "\t\t\t<string>NSStringPluralRuleType</string>\n"
+        result += "\t\t\t<key>NSStringFormatValueTypeKey</key>\n"
+        result += "\t\t\t<string>d</string>\n"
         # Replace Android's %s with iOS %@
-        result += plural_hash.map{|quantity,value| "#{tab(6)}<key>#{quantity}</key>\n#{tab(6)}<string>#{convert_placeholders_from_android_to_twine(value)}</string>"}.join("\n")
+        result += plural_hash.map{|quantity,value| "\t\t\t<key>#{quantity}</key>\n\t\t\t<string>#{convert_placeholders_from_android_to_twine(value)}</string>"}.join("\n")
         result += "\n"
-        result += "#{tab(4)}</dict>\n"
-        result += "#{tab(2)}</dict>\n"
+        result += "\t\t</dict>\n"
+        result += "\t</dict>\n"
       end
 
       def format_comment(definition, lang)
@@ -60,10 +60,6 @@ module Twine
 
       def read(io, lang)
         raise NotImplementedError.new("Reading \".stringdict\" files not implemented yet")
-      end
-
-      def tab(level)
-        ' ' * level
       end
 
       def should_include_definition(definition, lang)

--- a/lib/twine/formatters/apple_plural.rb
+++ b/lib/twine/formatters/apple_plural.rb
@@ -39,13 +39,19 @@ module Twine
       def format_plural_keys(key, plural_hash)
         result = "#{tab(2)}<key>#{key}</key>\n"
         result += "#{tab(2)}<dict>\n"
-        result += "#{tab(4)}<key>NSStringLocalizedFormatKey</key>\n#{tab(4)}<string>\%\#@value@</string>\n"
-        result += "#{tab(4)}<key>value</key>\n#{tab(4)}<dict>\n"
-        result += "#{tab(6)}<key>NSStringFormatSpecTypeKey</key>\n#{tab(6)}<string>NSStringPluralRuleType</string>\n"
-        result += "#{tab(6)}<key>NSStringFormatValueTypeKey</key>\n#{tab(6)}<string>d</string>\n"
+        result += "#{tab(4)}<key>NSStringLocalizedFormatKey</key>\n"
+        result += "#{tab(4)}<string>\%\#@value@</string>\n"
+        result += "#{tab(4)}<key>value</key>\n"
+        result += "#{tab(4)}<dict>\n"
+        result += "#{tab(6)}<key>NSStringFormatSpecTypeKey</key>\n"
+        result += "#{tab(6)}<string>NSStringPluralRuleType</string>\n"
+        result += "#{tab(6)}<key>NSStringFormatValueTypeKey</key>\n"
+        "#{tab(6)}<string>d</string>\n"
         # Replace Android's %s with iOS %@
         result += plural_hash.map{|quantity,value| "#{tab(6)}<key>#{quantity}</key>\n#{tab(6)}<string>#{convert_placeholders_from_android_to_twine(value)}</string>"}.join("\n")
-        result += "\n#{tab(4)}</dict>\n#{tab(2)}</dict>\n"
+        result += "\n"
+        result += "#{tab(4)}</dict>\n"
+        result += "#{tab(2)}</dict>\n"
       end
 
       def format_comment(definition, lang)

--- a/test/fixtures/formatter_android.xml
+++ b/test/fixtures/formatter_android.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<!-- SECTION: Section 1 -->
-	<!-- comment key1 -->
-	<string name="key1">value1-english</string>
-	<string name="key2">value2-english</string>
+    <!-- SECTION: Section 1 -->
+    <!-- comment key1 -->
+    <string name="key1">value1-english</string>
+    <string name="key2">value2-english</string>
 
-	<!-- SECTION: Section 2 -->
-	<string name="key3">value3-english</string>
-	<!-- comment key4 -->
-	<string name="key4">value4-english</string>
+    <!-- SECTION: Section 2 -->
+    <string name="key3">value3-english</string>
+    <!-- comment key4 -->
+    <string name="key4">value4-english</string>
 </resources>


### PR DESCRIPTION
This addresses indentation in these localisation files:

Android - use `4*sp` and fix a mixed indent on plural forms
iOS - use `\t`

These align with Weblate choices which reduces the diff conflicts to a minimum and at least allows easier exposure of any other issues. Since the target files are in any case generated by Twine, and not edited by users this choice shouldn't be that problematic.