### PR TITLE
Twine parsing improvements

### DIFF
--- a/python_twine/README.md
+++ b/python_twine/README.md
@@ -9,6 +9,59 @@ cd python_twine
 pip install -e .
 ```
 
+## Usage
+
+### Generate Android resource files from string.txt
+
+```bash
+# Generate a single localization file
+python twine_cli.py generate-localization-file \
+    strings.txt \
+    strings.xml \
+    --tags android-app \
+    --lang en
+
+# Generate all localization files for Spanish
+python twine_cli.py generate-all-localization-files \
+    strings.txt \
+    $OMAPS_REPO/android/app/src/main/res \
+    --tags android-app \
+    --lang es
+
+# Generate all localization files for all available languages
+python twine_cli.py generate-all-localization-files \
+    strings.txt \
+    $OMAPS_REPO/android/sdk/src/main/res \
+    --tags android,android-sdk
+
+# Consume a translation file and update strings.txt file
+# It's better to assign developer language with `-d en` because of Apple .strings file.
+# Untranslated values are replaced with default (English) values in .strings
+# And Twine needs to know default lang to ignore untranslated strings.
+python twine_cli.py consume-localization-file \
+    strings.txt \
+    $OMAPS_REPO/android/app/src/main/res/values-ja/strings.xml
+    -t android,android-app
+    -f android \
+    -d en \
+    --lang ja
+
+# Consume all translations and update strings.txt file
+# It's better to assign developer language with `-d en` because of Apple .strings file.
+# Untranslated values are replaced with default (English) values in .strings
+# And Twine needs to know default lang to ignore untranslated strings.
+python twine_cli.py consume-all-localization-files \
+    strings.txt \
+    $OMAPS_REPO/iphone/Maps/LocalizedStrings
+    -t apple,apple-maps \
+    -f apple \
+    -d en \
+    --lang ja
+
+# Validate Twine file
+python twine_cli.py validate-twine-file strings.txt
+```
+
 ## Project Structure
 
 ```
@@ -114,24 +167,6 @@ pytest
 - Test suite conversion
 - Archive support (zip handling)
 - Plugin system
-
-## Usage
-
-Once complete, usage will match the Ruby version:
-
-```bash
-# Generate a single localization file
-twine generate-localization-file twine.txt output.xml --lang en
-
-# Generate all localization files
-twine generate-all-localization-files twine.txt ./locales/
-
-# Consume translations
-twine consume-localization-file twine.txt input.xml --lang es
-
-# Validate Twine file
-twine validate-twine-file twine.txt
-```
 
 ## Contributing
 

--- a/python_twine/tests/test_formatters.py
+++ b/python_twine/tests/test_formatters.py
@@ -7,14 +7,44 @@ from pathlib import Path
 
 import pytest
 
+from twine.formatters.django import DjangoFormatter
+from twine.formatters.flash import FlashFormatter
 from twine.twine_file import TwineFile, TwineSection, TwineDefinition
 from twine.formatters.android import AndroidFormatter
 from twine.formatters.apple import AppleFormatter
 from twine.formatters.gettext import GettextFormatter
 from twine.formatters.jquery import JQueryFormatter
 
+class FormatterTestData:
+    def check_test_keys(self, twine_file: TwineFile):
+        # Check translations in twine_file
+        for i in range(1, 5):
+            key = f"key{i}"
+            assert key in twine_file.definitions_by_key
+            assert (
+                    twine_file.definitions_by_key[key].translations["en"]
+                    == f"value{i}-english"
+            )
 
-class TestAndroidFormatter:
+    def check_test_comments(self, twine_file: TwineFile):
+        # Check comments
+        assert twine_file.definitions_by_key["key1"].comment == "comment key1"
+        assert twine_file.definitions_by_key["key4"].comment == "comment key4"
+
+    def check_test_sections(self, twine_file: TwineFile):
+        # Check sections
+        assert len(twine_file.sections) == 2
+        assert {s.name for s in twine_file.sections} == {"Section 1", "Section 2"}
+
+        # Pick "Section 1" by name and check included keys
+        section1 = next(s for s in twine_file.sections if s.name == "Section 1")
+        assert [d.key for d in section1.definitions] == ["key1", "key2"]
+
+        # Pick "Section 2" by name and check included keys
+        section2 = next(s for s in twine_file.sections if s.name == "Section 2")
+        assert [d.key for d in section2.definitions] == ["key3", "key4"]
+
+class TestAndroidFormatter(FormatterTestData):
     """Test Android XML formatter."""
 
     @pytest.fixture
@@ -38,17 +68,13 @@ class TestAndroidFormatter:
             formatter.read(f, "en")
 
         # Check translations were read
-        for i in range(1, 5):
-            key = f"key{i}"
-            assert key in formatter.twine_file.definitions_by_key
-            assert (
-                formatter.twine_file.definitions_by_key[key].translations["en"]
-                == f"value{i}-english"
-            )
+        self.check_test_keys(formatter.twine_file)
 
-        # Check comments
-        assert formatter.twine_file.definitions_by_key["key1"].comment == "comment key1"
-        assert formatter.twine_file.definitions_by_key["key4"].comment == "comment key4"
+        # Check loaded comments
+        self.check_test_comments(formatter.twine_file)
+
+        # Check sections
+        self.check_test_sections(formatter.twine_file)
 
     def test_read_multiline_translation(self, formatter):
         """Test reading multiline translations."""
@@ -209,7 +235,7 @@ class TestAndroidFormatter:
         cdata = '<![CDATA[ New\\nline\n ]]>'
         assert formatter.escape_value(cdata) == cdata
 
-class TestAppleFormatter:
+class TestAppleFormatter(FormatterTestData):
     """Test Apple .strings formatter."""
 
     @pytest.fixture
@@ -231,19 +257,14 @@ class TestAppleFormatter:
         fixture_path = fixtures_dir / "formatter_apple.strings"
         with open(fixture_path, "r", encoding="utf-8") as f:
             formatter.read(f, "en")
-
         # Check translations were read
-        for i in range(1, 5):
-            key = f"key{i}"
-            assert key in formatter.twine_file.definitions_by_key
-            assert (
-                formatter.twine_file.definitions_by_key[key].translations["en"]
-                == f"value{i}-english"
-            )
+        self.check_test_keys(formatter.twine_file)
 
-        # Check comments
-        assert formatter.twine_file.definitions_by_key["key1"].comment == "comment key1"
-        assert formatter.twine_file.definitions_by_key["key4"].comment == "comment key4"
+        # Check loaded comments
+        self.check_test_comments(formatter.twine_file)
+
+        # Check sections
+        self.check_test_sections(formatter.twine_file)
 
     def test_format_file(self, formatter):
         """Test generating Apple .strings output."""
@@ -264,8 +285,7 @@ class TestAppleFormatter:
         assert "/* A greeting */" in output
         assert '"greeting" = "Hello World";' in output
 
-
-class TestGettextFormatter:
+class TestGettextFormatter(FormatterTestData):
     """Test Gettext .po formatter."""
 
     @pytest.fixture
@@ -287,15 +307,14 @@ class TestGettextFormatter:
         fixture_path = fixtures_dir / "formatter_gettext.po"
         with open(fixture_path, "r", encoding="utf-8") as f:
             formatter.read(f, "en")
-
         # Check translations were read
-        for i in range(1, 5):
-            key = f"key{i}"
-            assert key in formatter.twine_file.definitions_by_key
-            assert (
-                formatter.twine_file.definitions_by_key[key].translations["en"]
-                == f"value{i}-english"
-            )
+        self.check_test_keys(formatter.twine_file)
+
+        # Check loaded comments
+        self.check_test_comments(formatter.twine_file)
+
+        # Check sections
+        self.check_test_sections(formatter.twine_file)
 
     def test_read_multiline_po(self, formatter, fixtures_dir):
         """Test reading multiline Gettext format."""
@@ -306,8 +325,71 @@ class TestGettextFormatter:
         # Should have read multiline string correctly
         assert len(formatter.twine_file.definitions_by_key) > 0
 
+class TestDjangoFormatter(FormatterTestData):
+    """Test Django .po formatter."""
 
-class TestJQueryFormatter:
+    @pytest.fixture
+    def formatter(self):
+        """Create formatter with empty TwineFile."""
+        twine_file = TwineFile()
+        formatter = DjangoFormatter()
+        formatter.twine_file = twine_file
+        formatter.options = {"consume_all": True, "consume_comments": True}
+        return formatter
+
+    @pytest.fixture
+    def fixtures_dir(self):
+        """Get fixtures directory path."""
+        return Path(__file__).parent / "fixtures"
+
+    def test_read_format(self, formatter, fixtures_dir):
+        """Test reading Gettext .po format."""
+        fixture_path = fixtures_dir / "formatter_django.po"
+        with open(fixture_path, "r", encoding="utf-8") as f:
+            formatter.read(f, "en")
+
+        # Check translations were read
+        self.check_test_keys(formatter.twine_file)
+
+        # Check loaded comments
+        self.check_test_comments(formatter.twine_file)
+
+        # Check sections
+        self.check_test_sections(formatter.twine_file)
+
+class TestFlashFormatter(FormatterTestData):
+    """Test Flash .properties formatter."""
+
+    @pytest.fixture
+    def formatter(self):
+        """Create formatter with empty TwineFile."""
+        twine_file = TwineFile()
+        formatter = FlashFormatter()
+        formatter.twine_file = twine_file
+        formatter.options = {"consume_all": True, "consume_comments": True}
+        return formatter
+
+    @pytest.fixture
+    def fixtures_dir(self):
+        """Get fixtures directory path."""
+        return Path(__file__).parent / "fixtures"
+
+    def test_read_format(self, formatter, fixtures_dir):
+        """Test reading Gettext .po format."""
+        fixture_path = fixtures_dir / "formatter_flash.properties"
+        with open(fixture_path, "r", encoding="utf-8") as f:
+            formatter.read(f, "en")
+
+        # Check translations were read
+        self.check_test_keys(formatter.twine_file)
+
+        # Check loaded comments
+        self.check_test_comments(formatter.twine_file)
+
+        # Check sections
+        self.check_test_sections(formatter.twine_file)
+
+class TestJQueryFormatter(FormatterTestData):
     """Test jQuery JSON formatter."""
 
     @pytest.fixture
@@ -331,13 +413,7 @@ class TestJQueryFormatter:
             formatter.read(f, "en")
 
         # Check translations were read
-        for i in range(1, 5):
-            key = f"key{i}"
-            assert key in formatter.twine_file.definitions_by_key
-            assert (
-                formatter.twine_file.definitions_by_key[key].translations["en"]
-                == f"value{i}-english"
-            )
+        self.check_test_keys(formatter.twine_file)
 
     def test_read_nested_format(self, formatter, fixtures_dir):
         """Test reading nested jQuery JSON format."""

--- a/python_twine/tests/test_formatters.py
+++ b/python_twine/tests/test_formatters.py
@@ -112,7 +112,7 @@ class TestAndroidFormatter:
 
     def test_escape_ampersand(self, formatter):
         """Test ampersand escaping."""
-        formatter.set_translation_for_key("key1", "en", "this &amp; that")
+        formatter.set_translation_for_key("key1", "en", "this &amp; that", "Section A")
         assert (
             formatter.twine_file.definitions_by_key["key1"].translations["en"]
             == "this & that"
@@ -120,7 +120,7 @@ class TestAndroidFormatter:
 
     def test_escape_less_than(self, formatter):
         """Test less-than escaping."""
-        formatter.set_translation_for_key("key1", "en", "this &lt; that")
+        formatter.set_translation_for_key("key1", "en", "this &lt; that", "Section B")
         assert (
             formatter.twine_file.definitions_by_key["key1"].translations["en"]
             == "this < that"
@@ -128,7 +128,7 @@ class TestAndroidFormatter:
 
     def test_escape_apostrophe(self, formatter):
         """Test apostrophe escaping."""
-        formatter.set_translation_for_key("key1", "en", "it\\'s complicated")
+        formatter.set_translation_for_key("key1", "en", "it\\'s complicated", "Section C")
         assert (
             formatter.twine_file.definitions_by_key["key1"].translations["en"]
             == "it's complicated"
@@ -136,7 +136,7 @@ class TestAndroidFormatter:
 
     def test_placeholder_conversion(self, formatter):
         """Test placeholder conversion from %s to %@."""
-        formatter.set_translation_for_key("key1", "en", "value %s")
+        formatter.set_translation_for_key("key1", "en", "value %s", "Section D")
         assert (
             formatter.twine_file.definitions_by_key["key1"].translations["en"]
             == "value %@"

--- a/python_twine/tests/test_formatters.py
+++ b/python_twine/tests/test_formatters.py
@@ -61,6 +61,25 @@ class TestAndroidFormatter(FormatterTestData):
         """Get fixtures directory path."""
         return Path(__file__).parent / "fixtures"
 
+    def test_language_inference(self, formatter):
+        lang = formatter.determine_language_given_path("/android/sdk/src/main/res/values/strings.xml")
+        assert lang is None
+
+        lang = formatter.determine_language_given_path("/android/sdk/src/main/res/values-fi/strings.xml")
+        assert lang == "fi"
+
+        lang = formatter.determine_language_given_path("/android/sdk/src/main/res/values-ast/strings.xml")
+        assert lang == "ast"
+
+        lang = formatter.determine_language_given_path("/android/sdk/src/main/res/values-ast/strings.xml")
+        assert lang == "ast"
+
+        lang = formatter.determine_language_given_path("/android/sdk/src/main/res/values-zh/strings.xml")
+        assert lang == "zh-Hans"
+
+        lang = formatter.determine_language_given_path("/android/sdk/src/main/res/values-zh-rHant/strings.xml")
+        assert lang == "zh-Hant"
+
     def test_read_format(self, formatter, fixtures_dir):
         """Test reading Android XML format."""
         fixture_path = fixtures_dir / "formatter_android.xml"

--- a/python_twine/twine/cli.py
+++ b/python_twine/twine/cli.py
@@ -182,14 +182,16 @@ class CLI:
         # Convert to dict for compatibility
         options = vars(parsed)
 
-        # Parse tags into the expected format
+        # Parse tags into groups. Tags within a group have "OR" meaning. Groups are joined with "AND".
+        # For example `--tags android,apple --tags maps` means filter by "(android OR apple) AND (maps)"
+        # Or another `--tags android-sdk --tags ~android-app` means filter by "(android-sdk) AND (not android-app)"
         if "tags" in options and options["tags"]:
             # Convert list of tag strings to list of lists
-            # Support tag syntax: tag1,tag2 for OR and multiple --tags for AND
-            tags = []
+            tag_groups = []
             for tag_group in options["tags"]:
-                tags += [t.strip() for t in tag_group.split(",")]
-            options["tags"] = tags
+                tags = [t.strip() for t in tag_group.split(",")]
+                tag_groups.append(tags)
+            options["tags"] = tag_groups
         else:
             options["tags"] = None
 

--- a/python_twine/twine/formatters/__init__.py
+++ b/python_twine/twine/formatters/__init__.py
@@ -94,11 +94,14 @@ class AbstractFormatter(ABC):
         if lang not in self.twine_file.language_codes:
             self.twine_file.add_language_code(lang)
 
-    def get_section_or_create(self, section_name) -> TwineSection:
+    def get_section(self, section_name) -> Optional[TwineSection]:
         # Find or create a section by name
-        section = next(
+        return next(
             (s for s in self.twine_file.sections if s.name == section_name), None
         )
+
+    def get_section_or_create(self, section_name) -> TwineSection:
+        section = self.get_section(section_name)
 
         if not section:
             section = TwineSection(section_name)

--- a/python_twine/twine/formatters/__init__.py
+++ b/python_twine/twine/formatters/__init__.py
@@ -54,7 +54,7 @@ class AbstractFormatter(ABC):
             "You must implement default_file_name in your formatter class."
         )
 
-    def set_translation_for_key(self, key: str, lang: str, value: str):
+    def set_translation_for_key(self, key: str, lang: str, value: str, section_name:Optional[str]):
         """Set a translation value for a key in a specific language."""
         # Normalize newlines
         value = value.replace("\n", "\\n")
@@ -75,14 +75,7 @@ class AbstractFormatter(ABC):
         elif self.options.get("consume_all"):
             print(f"Adding new definition '{key}' to twine file.", file=twine.stdout)
 
-            # Find or create "Uncategorized" section
-            current_section = next(
-                (s for s in self.twine_file.sections if s.name == "Uncategorized"), None
-            )
-
-            if not current_section:
-                current_section = TwineSection("Uncategorized")
-                self.twine_file.sections.insert(0, current_section)
+            current_section = self.get_section_or_create(section_name or "Uncategorized")
 
             current_definition = TwineDefinition(key)
             current_section.definitions.append(current_definition)
@@ -100,6 +93,18 @@ class AbstractFormatter(ABC):
         # Add language code if not present
         if lang not in self.twine_file.language_codes:
             self.twine_file.add_language_code(lang)
+
+    def get_section_or_create(self, section_name) -> TwineSection:
+        # Find or create a section by name
+        section = next(
+            (s for s in self.twine_file.sections if s.name == section_name), None
+        )
+
+        if not section:
+            section = TwineSection(section_name)
+            self.twine_file.sections.insert(0, section)
+
+        return section
 
     def set_comment_for_key(self, key: str, comment: str):
         """Set a comment for a key."""

--- a/python_twine/twine/formatters/__init__.py
+++ b/python_twine/twine/formatters/__init__.py
@@ -12,6 +12,12 @@ import twine
 from twine.twine_file import TwineFile, TwineDefinition, TwineSection
 from twine.output_processor import OutputProcessor
 
+def flatten(input: List[List[str]]) -> List[str]:
+    flat = []
+    for group in input:
+        flat += group
+    return flat
+
 class AbstractFormatter(ABC):
     """Base class for all format formatters."""
 
@@ -74,7 +80,8 @@ class AbstractFormatter(ABC):
                            f"for key '{key}' and lang '{lang}' (comment '{definition.comment}').")
                     self.add_validation_error(msg)
                 definition.translations[lang] = value
-            definition.add_tags(self.options["tags"])
+            if "tags" in self.options:
+                definition.add_tags(flatten(self.options["tags"]))
 
         elif self.options.get("consume_all"):
             print(f"Adding new definition '{key}' to twine file.", file=twine.stdout)
@@ -83,7 +90,8 @@ class AbstractFormatter(ABC):
 
             current_definition = TwineDefinition(key)
             current_section.definitions.append(current_definition)
-            current_definition.add_tags(self.options["tags"])
+            if "tags" in self.options:
+                current_definition.add_tags(flatten(self.options["tags"]))
 
             self.twine_file.definitions_by_key[key] = current_definition
             current_definition.translations[lang] = value

--- a/python_twine/twine/formatters/__init__.py
+++ b/python_twine/twine/formatters/__init__.py
@@ -74,6 +74,7 @@ class AbstractFormatter(ABC):
                            f"for key '{key}' and lang '{lang}' (comment '{definition.comment}').")
                     self.add_validation_error(msg)
                 definition.translations[lang] = value
+            definition.add_tags(self.options["tags"])
 
         elif self.options.get("consume_all"):
             print(f"Adding new definition '{key}' to twine file.", file=twine.stdout)
@@ -82,10 +83,7 @@ class AbstractFormatter(ABC):
 
             current_definition = TwineDefinition(key)
             current_section.definitions.append(current_definition)
-
-            # Set tags if provided
-            if self.options.get("tags"):
-                current_definition.tags = self.options["tags"]
+            current_definition.add_tags(self.options["tags"])
 
             self.twine_file.definitions_by_key[key] = current_definition
             current_definition.translations[lang] = value

--- a/python_twine/twine/formatters/__init__.py
+++ b/python_twine/twine/formatters/__init__.py
@@ -4,15 +4,13 @@ Abstract base formatter for all localization format implementations.
 
 import os
 import re
-import sys
 from abc import ABC, abstractmethod
-from typing import Optional, Dict, TextIO
+from typing import Optional, Dict, TextIO, List
 from pathlib import Path
 
 import twine
 from twine.twine_file import TwineFile, TwineDefinition, TwineSection
 from twine.output_processor import OutputProcessor
-
 
 class AbstractFormatter(ABC):
     """Base class for all format formatters."""
@@ -23,6 +21,7 @@ class AbstractFormatter(ABC):
     def __init__(self):
         self.twine_file = TwineFile()
         self.options: Dict = {}
+        self.validation_errors: List[str] = []
 
     @abstractmethod
     def format_name(self) -> str:
@@ -70,6 +69,10 @@ class AbstractFormatter(ABC):
 
             # Only set if no reference or value differs from reference
             if not reference or value != reference.translations.get(lang):
+                if lang in definition.translations and definition.translations[lang] != value:
+                    msg = (f"Translation '{value}' overrides existing translation '{definition.translations[lang]}' "
+                           f"for key '{key}' and lang '{lang}' (comment '{definition.comment}').")
+                    self.add_validation_error(msg)
                 definition.translations[lang] = value
 
         elif self.options.get("consume_all"):
@@ -126,9 +129,9 @@ class AbstractFormatter(ABC):
             # Only set if no reference or comment differs from reference
             if not reference or comment != reference.raw_comment:
                 if definition.comment is not None and definition.comment != comment:
-                    print(f"Warning: translation overrides comment '{definition.comment}' -> '{comment}'. "
-                          f"The same key '{key}' has different comments in some translations.",
-                          file=sys.stderr)
+                    msg = (f"Translation overrides comment '{definition.comment}' -> '{comment}'. "
+                           f"The same key '{key}' has different comments in some translations.")
+                    self.add_validation_error(msg)
                 definition.comment = comment
 
     def determine_language_given_path(self, path: str) -> Optional[str]:
@@ -164,6 +167,12 @@ class AbstractFormatter(ABC):
     def read(self, io: TextIO, lang: str):
         """Read and parse a localization file."""
         raise NotImplementedError("You must implement read in your formatter class.")
+
+    def add_validation_error(self, msg: str):
+        self.validation_errors.append(msg)
+
+    def reset_validation_errors(self):
+        self.validation_errors = []
 
     def format_file(self, lang: str) -> Optional[str]:
         """Format the complete file for a language."""

--- a/python_twine/twine/formatters/android.py
+++ b/python_twine/twine/formatters/android.py
@@ -99,6 +99,9 @@ class AndroidFormatter(AbstractFormatter):
         # Unescape @ signs
         value = value.replace("\\@", "@")
 
+        # Unescape \n
+        value = value.replace("\n\\n", "\n")
+
         # Convert \u0020 space escapes
         def replace_spaces(match):
             spaces = match.group(0)
@@ -152,7 +155,6 @@ class AndroidFormatter(AbstractFormatter):
                 # Add tail text if any (text after the last child element)
                 # Note: child.tail is text AFTER the element, not inside
 
-                value = value.replace("\n\\n", "\n")
                 self.set_translation_for_key(key, lang, value, current_section)
 
                 if comment:

--- a/python_twine/twine/formatters/android.py
+++ b/python_twine/twine/formatters/android.py
@@ -152,6 +152,7 @@ class AndroidFormatter(AbstractFormatter):
                 # Add tail text if any (text after the last child element)
                 # Note: child.tail is text AFTER the element, not inside
 
+                value = value.replace("\n\\n", "\n")
                 self.set_translation_for_key(key, lang, value, current_section)
 
                 if comment:

--- a/python_twine/twine/formatters/android.py
+++ b/python_twine/twine/formatters/android.py
@@ -66,7 +66,7 @@ class AndroidFormatter(AbstractFormatter):
 
             # values-{lang} or values-{lang}-r{region}
             match = re.match(
-                r"^values-([a-z]{2}(-r[a-z]{2})?)$", segment, re.IGNORECASE
+                r"^values-([a-z]{2,3}(-r[a-z]{2,4})?)$", segment, re.IGNORECASE
             )
             if match:
                 lang = match.group(1).replace("-r", "-")

--- a/python_twine/twine/formatters/android.py
+++ b/python_twine/twine/formatters/android.py
@@ -84,7 +84,7 @@ class AndroidFormatter(AbstractFormatter):
             result = re.sub(r"-([A-Z])", r"-r\1", result)
             return result
 
-    def set_translation_for_key(self, key: str, lang: str, value: str):
+    def set_translation_for_key(self, key: str, lang: str, value: str, section_name: Optional[str]):
         """Set translation, handling Android-specific unescaping."""
         # Unescape HTML entities
         value = html.unescape(value)
@@ -106,7 +106,7 @@ class AndroidFormatter(AbstractFormatter):
 
         value = re.sub(r"(\\u0020)+", replace_spaces, value)
 
-        super().set_translation_for_key(key, lang, value)
+        super().set_translation_for_key(key, lang, value, section_name)
 
     def read(self, io: TextIO, lang: str):
         """Read Android XML strings file."""
@@ -122,14 +122,18 @@ class AndroidFormatter(AbstractFormatter):
             raise TwineError(f"Failed to parse XML: {e}")
 
         comment = None
+        current_section = None
 
         for child in root:
             # Handle comments (they have a callable tag function)
             if callable(child.tag):
                 content_text = child.text.strip() if child.text else ""
                 content_text = re.sub(r"\s+", " ", content_text)
-                if content_text and not content_text.startswith("SECTION:"):
-                    comment = content_text
+                if content_text:
+                    if content_text.startswith("SECTION:"):
+                        current_section = content_text[8:].strip()
+                    else:
+                        comment = content_text
 
             # Handle string elements
             elif child.tag == "string":
@@ -148,7 +152,7 @@ class AndroidFormatter(AbstractFormatter):
                 # Add tail text if any (text after the last child element)
                 # Note: child.tail is text AFTER the element, not inside
 
-                self.set_translation_for_key(key, lang, value)
+                self.set_translation_for_key(key, lang, value, current_section)
 
                 if comment:
                     self.set_comment_for_key(key, comment)

--- a/python_twine/twine/formatters/apple.py
+++ b/python_twine/twine/formatters/apple.py
@@ -77,11 +77,12 @@ class AppleFormatter(AbstractFormatter):
                 key = key.replace('\\"', '"')
                 value = value.replace('\\"', '"')
 
-                self.set_translation_for_key(key, lang, value, current_section)
+                if not self.match_default_lang_translation(key, lang, value):
+                    self.set_translation_for_key(key, lang, value, current_section)
 
-                if last_comment:
-                    self.set_comment_for_key(key, last_comment)
-                    last_comment = None
+                    if last_comment:
+                        self.set_comment_for_key(key, last_comment)
+                        last_comment = None
 
             # Match comments: /* comment */
             comment_match = re.match(r"/\* (.*) \*/", line)
@@ -95,6 +96,20 @@ class AppleFormatter(AbstractFormatter):
             elif not key_value_match:
                 # Reset comment if line doesn't match key=value
                 last_comment = None
+
+    def match_default_lang_translation(self, key:str, lang:str, value:str):
+        """ Apple strings file for non-default language (es, de, fr, etc) contains
+            default value for not translated keys. That's why in Slovenian .strings
+            file you can find english words.
+            If `value` matches translation from default language, it means that
+            this string is not translated.
+        """
+        default_lang = self.twine_file.get_developer_language_code()
+        if default_lang is None:
+            return False
+        if default_lang == lang:
+            return False
+        return self.twine_file.definitions_by_key[key].translations[default_lang] == value
 
     def format_file(self, lang: str) -> Optional[str]:
         """Format file with trailing newline."""

--- a/python_twine/twine/formatters/apple.py
+++ b/python_twine/twine/formatters/apple.py
@@ -55,18 +55,19 @@ class AppleFormatter(AbstractFormatter):
     def read(self, io: TextIO, lang: str):
         """Read Apple .strings file."""
         last_comment = None
+        current_section = None
 
         for line in io:
             # Match: key = "value" or "key" = "value"
             # Key may be quoted or unquoted, value is always quoted
-            match = re.match(
+            key_value_match = re.match(
                 r'^\s*((?:"(?:[^"\\]|\\.)+")| (?:[^"\s=]+))\s*=\s*"((?:[^"\\]|\\.)*)"',
                 line,
             )
 
-            if match:
-                key = match.group(1).strip()
-                value = match.group(2)
+            if key_value_match:
+                key = key_value_match.group(1).strip()
+                value = key_value_match.group(2)
 
                 # Remove quotes from key if quoted
                 if key.startswith('"') and key.endswith('"'):
@@ -76,7 +77,7 @@ class AppleFormatter(AbstractFormatter):
                 key = key.replace('\\"', '"')
                 value = value.replace('\\"', '"')
 
-                self.set_translation_for_key(key, lang, value)
+                self.set_translation_for_key(key, lang, value, current_section)
 
                 if last_comment:
                     self.set_comment_for_key(key, last_comment)
@@ -84,9 +85,15 @@ class AppleFormatter(AbstractFormatter):
 
             # Match comments: /* comment */
             comment_match = re.match(r"/\* (.*) \*/", line)
+            section_match = re.match(r"/\*{10} (.+) \*{10}/", line)
             if comment_match:
                 last_comment = comment_match.group(1)
-            elif not match:  # Reset comment if line doesn't match key=value
+            elif section_match:
+                current_section = section_match.group(1)
+                # Reset comment on a new section start
+                last_comment = None
+            elif not key_value_match:
+                # Reset comment if line doesn't match key=value
                 last_comment = None
 
     def format_file(self, lang: str) -> Optional[str]:

--- a/python_twine/twine/formatters/apple.py
+++ b/python_twine/twine/formatters/apple.py
@@ -80,9 +80,9 @@ class AppleFormatter(AbstractFormatter):
                 if not self.match_default_lang_translation(key, lang, value):
                     self.set_translation_for_key(key, lang, value, current_section)
 
-                    if last_comment:
-                        self.set_comment_for_key(key, last_comment)
-                        last_comment = None
+                if last_comment:
+                    self.set_comment_for_key(key, last_comment)
+                    last_comment = None
 
             # Match comments: /* comment */
             comment_match = re.match(r"/\* (.*) \*/", line)

--- a/python_twine/twine/formatters/django.py
+++ b/python_twine/twine/formatters/django.py
@@ -27,18 +27,27 @@ class DjangoFormatter(AbstractFormatter):
     def read(self, io: TextIO, lang: str):
         """Read Django .po file."""
         comment_regex = re.compile(r'^\s*#\. *"?(.*)"?$')
+        section_regex = re.compile(r'^\s*# -{9} (.+) -{9} #$')
         key_regex = re.compile(r'^msgid *"(.*)"$')
         value_regex = re.compile(r'^msgstr *"(.*)"$', re.MULTILINE)
 
         key = None
         value = None
         comment = None
+        current_section = None
 
         for line in io:
             # Extract comment
             comment_match = comment_regex.match(line)
             if comment_match:
                 comment = comment_match.group(1)
+                continue
+
+            section_match = section_regex.match(line)
+            if section_match:
+                current_section = section_match.group(1)
+                comment = None
+                continue
 
             # Extract key (msgid)
             key_match = key_regex.match(line)
@@ -55,7 +64,7 @@ class DjangoFormatter(AbstractFormatter):
 
             # Process entry when we have both key and value
             if key and value:
-                self.set_translation_for_key(key, lang, value)
+                self.set_translation_for_key(key, lang, value, current_section)
 
                 if comment and not comment.startswith("--------- "):
                     self.set_comment_for_key(key, comment)

--- a/python_twine/twine/formatters/flash.py
+++ b/python_twine/twine/formatters/flash.py
@@ -24,24 +24,25 @@ class FlashFormatter(AbstractFormatter):
     def default_file_name(self) -> str:
         return "resources.properties"
 
-    def set_translation_for_key(self, key: str, lang: str, value: str):
+    def set_translation_for_key(self, key: str, lang: str, value: str, section_name: Optional[str]):
         """Convert Flash placeholders to Twine format."""
         value = convert_placeholders_from_flash_to_twine(value)
-        super().set_translation_for_key(key, lang, value)
+        super().set_translation_for_key(key, lang, value, section_name)
 
     def read(self, io: TextIO, lang: str):
         """Read Flash properties file."""
         last_comment = None
+        current_section = None
 
         for line in io:
             # Match key=value line (handles escaped characters)
-            match = re.match(r'((?:[^"\\]|\\.)+)\s*=\s*((?:[^"\\]|\\.)*)', line)
+            key_value_match = re.match(r'((?:[^"\\]|\\.)+)\s*=\s*((?:[^"\\]|\\.)*)', line)
 
-            if match:
-                key = match.group(1)
-                value = match.group(2).strip()
+            if key_value_match:
+                key = key_value_match.group(1)
+                value = key_value_match.group(2).strip()
 
-                self.set_translation_for_key(key, lang, value)
+                self.set_translation_for_key(key, lang, value, current_section)
 
                 if last_comment:
                     self.set_comment_for_key(key, last_comment)
@@ -49,9 +50,15 @@ class FlashFormatter(AbstractFormatter):
 
             # Match comment line
             comment_match = re.match(r"# *(.*)", line)
+            section_match = re.match(r"## *(.*) *##", line)
             if comment_match:
                 last_comment = comment_match.group(1)
-            elif not match:
+            elif section_match:
+                current_section = section_match.group(1)
+                # Reset comment on a new section start
+                last_comment = None
+            elif not key_value_match:
+                # Reset comment if line doesn't match key=value
                 last_comment = None
 
     def format_sections(self, twine_file, lang: str) -> str:

--- a/python_twine/twine/formatters/flash.py
+++ b/python_twine/twine/formatters/flash.py
@@ -50,13 +50,13 @@ class FlashFormatter(AbstractFormatter):
 
             # Match comment line
             comment_match = re.match(r"# *(.*)", line)
-            section_match = re.match(r"## *(.*) *##", line)
-            if comment_match:
-                last_comment = comment_match.group(1)
-            elif section_match:
+            section_match = re.match(r"## +(.*) +##", line)
+            if section_match:
                 current_section = section_match.group(1)
                 # Reset comment on a new section start
                 last_comment = None
+            elif comment_match:
+                last_comment = comment_match.group(1)
             elif not key_value_match:
                 # Reset comment if line doesn't match key=value
                 last_comment = None

--- a/python_twine/twine/formatters/gettext.py
+++ b/python_twine/twine/formatters/gettext.py
@@ -28,12 +28,14 @@ class GettextFormatter(AbstractFormatter):
     def read(self, io: TextIO, lang: str):
         """Read Gettext .po file."""
         comment_regex = re.compile(r'#\.\s*"(.*)"$', re.MULTILINE)
+        section_regex = re.compile(r'# SECTION: (.+)$', re.MULTILINE)
         key_regex = re.compile(r'msgctxt\s+"(.*)"$', re.MULTILINE)
         value_regex = re.compile(r'msgid\s+"(.*)"$', re.MULTILINE)
 
         # Read file in chunks separated by double newlines
         content = io.read()
         items = content.split("\n\n")
+        current_sections = None
 
         for item in items:
             if not item.strip() or item.startswith('msgid ""'):
@@ -47,6 +49,11 @@ class GettextFormatter(AbstractFormatter):
             comment_match = comment_regex.search(item)
             if comment_match:
                 comment = comment_match.group(1)
+
+            # Extract section
+            section_match = section_regex.search(item)
+            if section_match:
+                current_sections = section_match.group(1)
 
             # Extract key (msgctxt)
             key_match = key_regex.search(item)
@@ -63,7 +70,7 @@ class GettextFormatter(AbstractFormatter):
 
             # Set translation if we have both key and value
             if key and value:
-                self.set_translation_for_key(key, lang, value)
+                self.set_translation_for_key(key, lang, value, current_sections)
 
                 if comment and not comment.startswith("SECTION:"):
                     self.set_comment_for_key(key, comment)

--- a/python_twine/twine/formatters/jquery.py
+++ b/python_twine/twine/formatters/jquery.py
@@ -39,7 +39,7 @@ class JQueryFormatter(AbstractFormatter):
             for key2, value2 in value.items():
                 self.set_translation_for_key_recursive(f"{key}.{key2}", lang, value2)
         else:
-            self.set_translation_for_key(key, lang, str(value))
+            self.set_translation_for_key(key, lang, str(value), section_name=None)
 
     def read(self, io: TextIO, lang: str):
         """Read jQuery-localize JSON file."""

--- a/python_twine/twine/formatters/tizen.py
+++ b/python_twine/twine/formatters/tizen.py
@@ -77,9 +77,11 @@ class TizenFormatter(AbstractFormatter):
         key = None
         value = None
         comment = None
+        current_section = None
 
         key_regex = re.compile(r'<string name="(\w+)">')
         comment_regex = re.compile(r"<!-- (.*) -->")
+        section_regex = re.compile(r"<!-- SECTION: (.*) -->")
         value_regex = re.compile(r'<string name="\w+">(.*)</string>')
 
         for line in resources_content.split("\n"):
@@ -107,7 +109,7 @@ class TizenFormatter(AbstractFormatter):
                 else:
                     value = ""
 
-                self.set_translation_for_key(key, lang, value)
+                self.set_translation_for_key(key, lang, value, current_section)
 
                 if comment and not comment.startswith("SECTION:"):
                     self.set_comment_for_key(key, comment)
@@ -118,6 +120,12 @@ class TizenFormatter(AbstractFormatter):
             comment_match = comment_regex.search(line)
             if comment_match:
                 comment = comment_match.group(1)
+
+            # Check for section start
+            section_match = section_regex.search(line)
+            if section_match:
+                current_section = section_match.group(1)
+                comment = None
 
     def format_header(self, lang: str) -> str:
         """Generate Tizen XML header."""

--- a/python_twine/twine/runner.py
+++ b/python_twine/twine/runner.py
@@ -3,9 +3,10 @@ Runner orchestrates command execution for Twine.
 """
 
 from pathlib import Path
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, Iterable, Tuple
 
 import twine
+from twine.formatters import AbstractFormatter
 from twine.twine_file import TwineFile
 from twine import TwineError
 
@@ -179,6 +180,10 @@ class Runner:
         self.write_twine_data(self.options["twine_file"])
         print(f"Consumed {self.options['input_path']}", file=twine.stdout)
 
+        if formatter.validation_errors:
+            for msg in formatter.validation_errors:
+                print(f"  WARNING: {msg}")
+
     def consume_all_localization_files(self):
         """Import translations from all localization files."""
         input_path = Path(self.options["input_path"])
@@ -187,9 +192,55 @@ class Runner:
             raise TwineError(f"Directory does not exist: {input_path}")
 
         formatter = self._get_formatter()
-        file_name = self.options.get("file_name") or formatter.default_file_name()
 
         files_consumed = 0
+        validation_errors = {}
+
+        lang2file = dict(self.find_translation_files(input_path, formatter))
+
+        # Parse developer_language file first (if it's available).
+        if self.options.get("developer_language"):
+            default_lang = self.options.get("developer_language")
+            if default_lang in lang2file:
+                # First parse default language file.
+                # Apple .strings file for not-translated keys fallbacks to default value.
+                # We need to compare translations values to default values.
+                default_lang_path = lang2file[default_lang]
+                with open(default_lang_path, "r", encoding="UTF-8") as f:
+                    formatter.read(f, default_lang)
+
+                print(f"Consumed {default_lang_path}", file=twine.stdout)
+                if formatter.validation_errors:
+                    validation_errors[default_lang_path] = formatter.validation_errors
+                    for msg in formatter.validation_errors:
+                        print(f"  WARNING: {msg}")
+                formatter.reset_validation_errors()
+                files_consumed += 1
+
+                del lang2file[default_lang]
+
+        # Parse all files.
+        for lang, file_path in lang2file.items():
+            with open(file_path, "r", encoding="UTF-8") as f:
+                formatter.read(f, lang)
+
+            print(f"Consumed {file_path}", file=twine.stdout)
+            if formatter.validation_errors:
+                validation_errors[file_path] = formatter.validation_errors
+                for msg in formatter.validation_errors:
+                    print(f"  WARNING: {msg}")
+            formatter.reset_validation_errors()
+            files_consumed += 1
+
+        if files_consumed == 0:
+            raise TwineError(f"No files consumed from {input_path}")
+
+        # Export to Twine.
+        self.write_twine_data(self.options["twine_file"])
+
+    def find_translation_files(self, input_path: Path, formatter: AbstractFormatter) -> Iterable[Tuple[str, Path]]:
+        """ Iterate over files in `input_path` to find consumable by the formatter. """
+        file_name = self.options.get("file_name") or formatter.default_file_name()
 
         for item in input_path.iterdir():
             if not item.is_dir():
@@ -202,17 +253,7 @@ class Runner:
             file_path = item / file_name
             if not file_path.exists():
                 continue
-
-            with open(file_path, "r", encoding="UTF-8") as f:
-                formatter.read(f, lang)
-
-            print(f"Consumed {file_path}", file=twine.stdout)
-            files_consumed += 1
-
-        if files_consumed == 0:
-            raise TwineError(f"No files consumed from {input_path}")
-
-        self.write_twine_data(self.options["twine_file"])
+            yield lang, file_path
 
     def validate_twine_file(self):
         """Validate the Twine data file."""

--- a/python_twine/twine/twine_file.py
+++ b/python_twine/twine/twine_file.py
@@ -171,6 +171,11 @@ class TwineFile:
             self.language_codes.remove(code)
         self.language_codes.insert(0, code)
 
+    def get_developer_language_code(self) -> Optional[str]:
+        if self.language_codes:
+            return self.language_codes[0]
+        return None
+
     def read(self, path: str):
         """
         Read and parse a Twine file.

--- a/python_twine/twine/twine_file.py
+++ b/python_twine/twine/twine_file.py
@@ -38,13 +38,12 @@ class TwineDefinition:
         """Get the raw comment without reference fallback."""
         return self._comment
 
-    def add_tags(self, tags: Optional[List[str]]):
-        if tags:
-            if self.tags:
-                self.tags += tags
-            else:
-                self.tags = tags
-            self.tags = sorted(list(set(self.tags))) # Remove duplicates and sort
+    def add_tags(self, tags: List[str]):
+        if self.tags:
+            self.tags += tags
+        else:
+            self.tags = tags
+        self.tags = sorted(list(set(self.tags))) # Remove duplicates and sort
 
     def matches_tags(
         self, tags: Optional[List[List[str]]], include_untagged: bool

--- a/python_twine/twine/twine_file.py
+++ b/python_twine/twine/twine_file.py
@@ -38,6 +38,14 @@ class TwineDefinition:
         """Get the raw comment without reference fallback."""
         return self._comment
 
+    def add_tags(self, tags: Optional[List[str]]):
+        if tags:
+            if self.tags:
+                self.tags += tags
+            else:
+                self.tags = tags
+            self.tags = sorted(list(set(self.tags))) # Remove duplicates and sort
+
     def matches_tags(
         self, tags: Optional[List[List[str]]], include_untagged: bool
     ) -> bool:


### PR DESCRIPTION
Twine now parses section names from import files (Android XML, iOS .strings, etc) and exports to `strings.txt`. Covered with tests.

Also added validation to parser. When Twine tool parses Android XML, iOS .strings or other format it compares values to existing translations in `strings.txt`. If there are mismatches in translations or comments a Warning is printed.

### How to use:

1. Create empty `strings.txt` file (Required!)
2. Import Android strings:
  ```shell
python twine_cli.py consume-all-localization-files \
$OMAPS_REPO/data/strings/strings.txt \
$OMAPS_REPO/android/app/src/main/res \
-f android \
--tags android,android-app \
-a -c \
-d en
```

3. Import Android strings from "sdk" subfolder:
  ```shell
python twine_cli.py consume-all-localization-files \
$OMAPS_REPO/data/strings/strings.txt \
$OMAPS_REPO/android/sdk/src/main/res \
-f android \
--tags android,android-sdk \
-a -c \
-d en
```

4. Import iOS strings from "Maps" project (NOTE you could see warning for mismatched translations):
  ```shell
python twine_cli.py consume-all-localization-files \
$OMAPS_REPO/data/strings/strings.txt \
$OMAPS_REPO/iphone/Maps/LocalizedStrings \
-f apple \
--tags apple,apple-maps \
 -a -c \
-d en
```

5. Import iOS strings from "Chart" project (NOTE you could see warning for mismatched translations):
  ```shell
python twine_cli.py consume-all-localization-files \
$OMAPS_REPO/data/strings/strings.txt \
$OMAPS_REPO/iphone/Chart/Chart \
-f apple \
--tags apple,apple-chart \
 -a -c \
-d en
```

This will give you `strings.txt` generated from Android and iOS projects.