### PR TITLE
Write plural values in Twine format

### DIFF
--- a/python_twine/tests/fixtures/twine_plural_values.txt
+++ b/python_twine/tests/fixtures/twine_plural_values.txt
@@ -1,0 +1,9 @@
+[[Bookmarks]]
+    [bookmarks_places]
+        comment = Number of bookmarks on UI
+        en:one = %d bookmark
+        en:other = %d bookmarks
+        ru:one = %d метка
+        ru:few = %d метки
+        ru:many = %d меток
+        ru:other = %d меток

--- a/python_twine/tests/test_formatters_plural.py
+++ b/python_twine/tests/test_formatters_plural.py
@@ -1,0 +1,73 @@
+"""
+Tests for formatter classes.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from twine.twine_file import TwineFile, TwineDefinition, TwineSection
+
+
+class TestTwineFilePlural:
+    @pytest.fixture
+    def fixtures_dir(self):
+        """Get fixtures directory path."""
+        return Path(__file__).parent / "fixtures"
+
+    def test_write_plural_format(self):
+        import tempfile
+
+        twine_file = TwineFile()
+        num_edits_def = TwineDefinition("num_edits")
+
+        twine_file.definitions_by_key["num_edits"] = num_edits_def
+        twine_file.language_codes.append("en")
+        twine_file.sections = [TwineSection("OSM")]
+        twine_file.sections[0].definitions.append(num_edits_def)
+
+        # Put plural translations
+        num_edits_def.plural_translations["en"] = {
+            "one": "%d edit",
+            "other": "%d edits"
+        }
+
+        # Export
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            tmp_twine_path = tmpdirname + "/plural.txt"
+            twine_file.write(tmp_twine_path)
+            with open(tmp_twine_path, "rt") as fout:
+                twine_content = fout.read()
+
+            assert twine_content == """[[OSM]]
+\t[num_edits]
+\t\ten:one = %d edit
+\t\ten:other = %d edits
+"""
+
+    def test_read_plurals(self, fixtures_dir):
+        twine_file = TwineFile()
+        twine_file.read(str(fixtures_dir / "twine_plural_values.txt"))
+
+        assert twine_file.language_codes == ["en", "ru"]
+
+        assert "bookmarks_places" in twine_file.definitions_by_key
+        definition = twine_file.definitions_by_key["bookmarks_places"]
+
+        assert "en" in definition.translations
+        assert definition.translations["en"] == "%d bookmarks"  # "en:other" value is copied to translations
+        assert "en" in definition.plural_translations
+        assert definition.plural_translations["en"] == {
+            "one": "%d bookmark",
+            "other": "%d bookmarks"
+        }
+
+        assert "ru" in definition.translations
+        assert definition.translations["ru"] == "%d меток"  # "ru:other" value is copied to translations
+        assert "ru" in definition.plural_translations
+        assert definition.plural_translations["ru"] == {
+            "one": "%d метка",
+            "few": "%d метки",
+            "many": "%d меток",
+            "other": "%d меток"
+        }

--- a/python_twine/tests/test_twine_file.py
+++ b/python_twine/tests/test_twine_file.py
@@ -191,15 +191,32 @@ class TestTwineFile:
             with open(temp_path, "r") as f:
                 content = f.read()
 
-            assert "[[Test]]" in content
-            assert "[test_key]" in content
-            assert "en = Test" in content
-            assert "es = Prueba" in content
-            assert "comment = A test string" in content
-            assert "tags = test" in content
+            assert content == """[[Test]]
+\t[test_key]
+\t\tcomment = A test string
+\t\ttags = test
+\t\ten = Test
+\t\tes = Prueba
+"""
         finally:
             Path(temp_path).unlink()
 
+
+class TestWriter:
+    @pytest.fixture
+    def fixtures_dir(self):
+        """Get fixtures directory path."""
+        return Path(__file__).parent / "fixtures"
+
+    def test_accent_symbol(self, fixtures_dir):
+        twine_file = TwineFile()
+        twine_file.read(str(fixtures_dir / "twine_accent_values.txt"))
+        assert twine_file.definitions_by_key["value_with_leading_accent"].translations["en"] == '`value'
+        assert twine_file.definitions_by_key["value_with_trailing_accent"].translations["en"] == 'value`'
+        assert twine_file.definitions_by_key["value_with_leading_space"].translations["en"] == ' value'
+        assert twine_file.definitions_by_key["value_with_trailing_space"].translations["en"] == 'value '
+        assert twine_file.definitions_by_key["value_wrapped_by_spaces"].translations["en"] == ' value '
+        assert twine_file.definitions_by_key["value_wrapped_by_accents"].translations["en"] == '`value`'
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/python_twine/twine/twine_file.py
+++ b/python_twine/twine/twine_file.py
@@ -346,17 +346,33 @@ class TwineFile:
         self, definition: TwineDefinition, language: str, file
     ) -> Optional[str]:
         """Write a single translation value to file."""
-        value = definition.translations.get(language)
-        if not value:
-            return None
+        output = None
+        if language in definition.plural_translations:
+            # Write plurals:
+            #   ru:one = %d метка
+            #   ru:few = %d метки
+            #   ru:many = %d меток
+            #   ru:other = %d меток
+            output = ""
+            for quantity, value in definition.plural_translation_for_lang(language).items():
+                output += f"\t\t{language}:{quantity} = {escape_spaces_backticks(value)}\n"
 
-        # Wrap in backticks if starts/ends with space or already has backticks
-        if (
-            value.startswith(" ")
-            or value.endswith(" ")
-            or (value.startswith("`") and value.endswith("`"))
-        ):
-            value = f"`{value}`"
+        elif language in definition.translations:
+            singular_value = definition.translations[language]
+            # Write singular
+            output = f"\t\t{language} = {escape_spaces_backticks(singular_value)}\n"
 
-        file.write(f"\t\t{language} = {value}\n")
-        return value
+        if output:
+            file.write(output)
+        return output
+
+
+def escape_spaces_backticks(txt: str) -> str:
+    # Wrap in backticks if starts/ends with space or already has backticks
+    if (
+        txt.startswith(" ")
+        or txt.endswith(" ")
+        or (txt.startswith("`") and txt.endswith("`"))
+    ):
+        return f"`{txt}`"
+    return txt


### PR DESCRIPTION
Python and Ruby implementations both support reading of plural values but not writing.

It means that Twine can parse file:

```ini
[bookmarks_places]
    en:one = %d bookmark
    en:other = %d bookmarks
```

but when we write it back we get only

```ini
[bookmarks_places]
    en = %d bookmarks
```

This PR fixes Twine exporter for Python. So after the fix we can parse Android and iOS plurals into Twine format. And even export plurals from `strings.txt` back to Android and iOS (not implemented yet).