### PR TITLE
Changed Twine format padding.

### DIFF
--- a/python_twine/tests/fixtures/twine_accent_values.txt
+++ b/python_twine/tests/fixtures/twine_accent_values.txt
@@ -1,13 +1,19 @@
 [[Section]]
-	[value_with_leading_accent]
-		en = `value
-	[value_with_trailing_accent]
-		en = value`
-	[value_with_leading_space]
-		en = ` value`
-	[value_with_trailing_space]
-		en = `value `
-	[value_wrapped_by_spaces]
-		en = ` value `
-	[value_wrapped_by_accents]
-		en = ``value``
+
+[value_with_leading_accent]
+en = `value
+
+[value_with_trailing_accent]
+en = value`
+
+[value_with_leading_space]
+en = ` value`
+
+[value_with_trailing_space]
+en = `value `
+
+[value_wrapped_by_spaces]
+en = ` value `
+
+[value_wrapped_by_accents]
+en = ``value``

--- a/python_twine/tests/fixtures/twine_plural_values.txt
+++ b/python_twine/tests/fixtures/twine_plural_values.txt
@@ -1,9 +1,10 @@
 [[Bookmarks]]
-    [bookmarks_places]
-        comment = Number of bookmarks on UI
-        en:one = %d bookmark
-        en:other = %d bookmarks
-        ru:one = %d метка
-        ru:few = %d метки
-        ru:many = %d меток
-        ru:other = %d меток
+
+[bookmarks_places]
+comment = Number of bookmarks on UI
+en:one = %d bookmark
+en:other = %d bookmarks
+ru:one = %d метка
+ru:few = %d метки
+ru:many = %d меток
+ru:other = %d меток

--- a/python_twine/tests/test_formatters_plural.py
+++ b/python_twine/tests/test_formatters_plural.py
@@ -130,9 +130,10 @@ class TestTwineFilePlural:
                 twine_content = fout.read()
 
             assert twine_content == """[[OSM]]
-\t[num_edits]
-\t\ten:one = %d edit
-\t\ten:other = %d edits
+
+[num_edits]
+en:one = %d edit
+en:other = %d edits
 """
 
     def test_read_plurals(self, fixtures_dir):

--- a/python_twine/tests/test_twine_file.py
+++ b/python_twine/tests/test_twine_file.py
@@ -192,11 +192,12 @@ class TestTwineFile:
                 content = f.read()
 
             assert content == """[[Test]]
-\t[test_key]
-\t\tcomment = A test string
-\t\ttags = test
-\t\ten = Test
-\t\tes = Prueba
+
+[test_key]
+comment = A test string
+tags = test
+en = Test
+es = Prueba
 """
         finally:
             Path(temp_path).unlink()

--- a/python_twine/twine/formatters/android.py
+++ b/python_twine/twine/formatters/android.py
@@ -299,8 +299,8 @@ class AndroidFormatter(AbstractFormatter):
             lambda i: not inside_cdata(result, i)
         )
 
-        # Escape @ signs that aren't resource identifiers
-        resource_identifier_regex = re.compile(r"@(?!([a-z\.]+:)?[a-z+]+\/[a-zA-Z_]+)")
+        # escape non resource identifier @ signs (http://developer.android.com/guide/topics/resources/accessing-resources.html#ResourcesFromXml)
+        resource_identifier_regex = re.compile(r"@(?!([a-z\.]+:)?[a-z+]+\/[a-zA-Z_]+)")  # @[<package_name>:]<resource_type>/<resource_name>
         result = resource_identifier_regex.sub(r"\\@", result)
 
         return result

--- a/python_twine/twine/twine_file.py
+++ b/python_twine/twine/twine_file.py
@@ -371,20 +371,20 @@ class TwineFile:
                 f.write(f"[[{section.name}]]\n")
 
                 for definition in section.definitions:
-                    f.write(f"\t[{definition.key}]\n")
+                    f.write(f"\n[{definition.key}]\n")
 
                     # Write comment
                     if definition.raw_comment:
-                        f.write(f"\t\tcomment = {definition.raw_comment}\n")
+                        f.write(f"comment = {definition.raw_comment}\n")
 
                     # Write reference
                     if definition.reference_key:
-                        f.write(f"\t\tref = {definition.reference_key}\n")
+                        f.write(f"ref = {definition.reference_key}\n")
 
                     # Write tags
                     if definition.tags:
                         tag_str = ",".join(definition.tags)
-                        f.write(f"\t\ttags = {tag_str}\n")
+                        f.write(f"tags = {tag_str}\n")
 
                     # Write developer language first
                     if dev_lang:
@@ -413,12 +413,12 @@ class TwineFile:
             #   ru:other = %d меток
             output = ""
             for quantity, value in definition.plural_translation_for_lang(language).items():
-                output += f"\t\t{language}:{quantity} = {escape_spaces_backticks(value)}\n"
+                output += f"{language}:{quantity} = {escape_spaces_backticks(value)}\n"
 
         elif language in definition.translations:
             singular_value = definition.translations[language]
             # Write singular
-            output = f"\t\t{language} = {escape_spaces_backticks(singular_value)}\n"
+            output = f"{language} = {escape_spaces_backticks(singular_value)}\n"
 
         if output:
             file.write(output)


### PR DESCRIPTION
Removed `'\t'` padding.

Added extra space before `[key]` definition.