### PR TITLE
Removed extra new-line from Android resources formatter

### DIFF
--- a/python_twine/tests/test_formatters.py
+++ b/python_twine/tests/test_formatters.py
@@ -230,12 +230,12 @@ class TestAndroidFormatter(FormatterTestData):
 
         assert formatter.escape_value('<![C DATA[ <![CDATA[') == '&lt;![C DATA[ <![CDATA['
 
-    def test_writer_escape_newline(self, formatter):
-        """Test '\\n' escaping."""
-        assert formatter.escape_value('\\n') == '\n\\n'
-        assert formatter.escape_value('Downloading %@. You can now\\nproceed to the map.') == 'Downloading %\\@. You can now\n\\nproceed to the map.'
+    def test_writer_escape_at(self, formatter):
+        """Test '@' escaping."""
+        assert formatter.escape_value('Downloading %@. You can now\\nproceed to the map.') == 'Downloading %\\@. You can now\\nproceed to the map.'
+        assert formatter.escape_value('Press @strings/escape to stop.') == 'Press @strings/escape to stop.'
 
-        cdata = '<![CDATA[ New\\nline\n ]]>'
+        cdata = '<![CDATA[ New\nline\\n ]]>'
         assert formatter.escape_value(cdata) == cdata
 
 class TestAppleFormatter(FormatterTestData):

--- a/python_twine/twine/formatters/android.py
+++ b/python_twine/twine/formatters/android.py
@@ -225,7 +225,8 @@ class AndroidFormatter(AbstractFormatter):
         value = value.replace("\\@", "@")
 
         # Unescape \n
-        value = value.replace("\n\\n", "\n")
+        value = value.replace("\n\\n", "\n")  # Old escape format
+        value = value.replace("\\n", "\n")
 
         # Convert \u0020 space escapes
         def replace_spaces(match):
@@ -292,11 +293,6 @@ class AndroidFormatter(AbstractFormatter):
 
         result = replace_with_filter(result, "<", "&lt;",
             lambda i: is_non_tag(result, i)
-        )
-
-        # Escape newlines (unless in CDATA)
-        result = replace_with_filter(result, "\\n", "\n\\n",
-            lambda i: not inside_cdata(result, i)
         )
 
         # escape non resource identifier @ signs (http://developer.android.com/guide/topics/resources/accessing-resources.html#ResourcesFromXml)


### PR DESCRIPTION
Now for Android "\n" is not escaped to "\n\\n". No extra new line.