### PR TITLE
Validate unused strings

### DIFF
--- a/python_twine/README.md
+++ b/python_twine/README.md
@@ -62,6 +62,29 @@ python twine_cli.py consume-all-localization-files \
 python twine_cli.py validate-twine-file strings.txt
 ```
 
+### Validate strings.txt files
+
+Basic validation could be done with command:
+
+```bash
+python twine_cli.py validate-twine-file \
+    $OMAPS_REPO/data/strings/strings.txt
+```
+
+This command looks for keys duplicates, missing tags, extra symbols in key name, wrong placeholder formats.
+
+Also, you can get usage report by running:
+
+```bash
+python twine_cli.py validate-unused-strings \
+    $OMAPS_REPO/data/strings/strings.txt
+    --android-src-root $OMAPS_REPO/android
+    --core-src-root $OMAPS_REPO/libs
+    --ios-src-root $OMAPS_REPO/iphone
+```
+
+This command will print list of string in `strings.txt` which are not found in source code.
+
 ## Project Structure
 
 ```

--- a/python_twine/twine/cli.py
+++ b/python_twine/twine/cli.py
@@ -91,14 +91,35 @@ class CLI:
         CLI._add_consume_arguments(consume_all)
 
         # validate-twine-file
-        validate = subparsers.add_parser(
+        validate_twine = subparsers.add_parser(
             "validate-twine-file", help="Validate the Twine data file"
         )
-        validate.add_argument("twine_file", help="Path to Twine data file")
-        validate.add_argument(
+        validate_twine.add_argument("twine_file", help="Path to Twine data file")
+        validate_twine.add_argument(
             "--pedantic",
             action="store_true",
             help="Enable pedantic validation (e.g., require tags)",
+        )
+
+        # validate-unused-strings
+        validate_unused = subparsers.add_parser(
+            "validate-unused-strings", help="Search through Android and iOS source code to find unused strings"
+        )
+        validate_unused.add_argument("twine_file", help="Path to Twine data file")
+        validate_unused.add_argument(
+            "--android-src-root",
+            help="Path to Android source root directory",
+            default=None
+        )
+        validate_unused.add_argument(
+            "--ios-src-root",
+            help="Path to iOS source root directory",
+            default=None
+        )
+        validate_unused.add_argument(
+            "--core-src-root",
+            help="Path to C++ source root directory",
+            default=None
         )
 
         return parser

--- a/python_twine/twine/runner.py
+++ b/python_twine/twine/runner.py
@@ -390,7 +390,7 @@ class Runner:
         root_path = self.options['ios_src_root']
         return grep_folder(root_path, ["*.m", "*.mm", "*.swift", "*.h"], IOS_RE) | \
                grep_folder(root_path, ["*.m", "*.mm", "*.swift", "*.h"], IOS_NS_RE) | \
-               grep_folder(root_path, ["*.m", "*.mm", "*.swift", "*.h"], IOS_XML_RE)
+               grep_folder(root_path, ["*.xib"], IOS_XML_RE)
 
     def _grep_android_strings(self) -> Set[str]:
         # Search for localized strings in Android source code and resources.

--- a/python_twine/twine/runner.py
+++ b/python_twine/twine/runner.py
@@ -370,7 +370,7 @@ class Runner:
         unused = all_keys - total_grepped
         if len(unused):
             print(f"Found {len(unused)} definitions/keys which are no longer used in the codebase:")
-            print(*unused, sep="\n")
+            print(*sorted(unused), sep="\n")
             raise Exception("Unused definitions found")
         else:
             print("All good. There are no unused translation definitions/keys.")

--- a/python_twine/twine/runner.py
+++ b/python_twine/twine/runner.py
@@ -2,13 +2,25 @@
 Runner orchestrates command execution for Twine.
 """
 
+import re
 from pathlib import Path
-from typing import Optional, Dict, Any, Iterable, Tuple
+from typing import Optional, Dict, Any, Iterable, Tuple, Set
 
 import twine
-from twine.formatters import AbstractFormatter
-from twine.twine_file import TwineFile
 from twine import TwineError
+from twine.formatters import AbstractFormatter
+from twine.tools.grep import grep_folder
+from twine.twine_file import TwineFile
+
+CORE_RE = re.compile(r'\bGetLocalizedString\("(.*?)"\)')
+
+ANDROID_JAVA_RE = re.compile(r'\bR\.string\.([\w_]*)')
+ANDROID_JAVA_PLURAL_RE = re.compile(r'\bR\.plurals\.([\w_]*)')
+ANDROID_XML_RE = re.compile(r'@string/(.*?)\W')
+
+IOS_RE = re.compile(r'\bL\(.*?"(\w+)".*?(?:"(\w+)")?\)')
+IOS_NS_RE = re.compile(r'\bNSLocalizedString\(\s*?@?"(\w+)"')
+IOS_XML_RE = re.compile(r'\bvalue=\"(.*?)\"')
 
 
 class NullOutput:
@@ -335,6 +347,55 @@ class Runner:
                 print(f"WARNING: Definition '{key}' has no tags")
 
         print("Validation passed")
+
+    def validate_unused_strings(self):
+        if self.options['android_src_root'] is None and self.options['ios_src_root'] is None \
+            and self.options['core_src_root'] is None:
+            raise Exception("Please specify source path with --android-src-root or --ios-src-root or --core-src-root")
+
+        core_keys = self._grep_core_strings()
+        ios_keys = self._grep_ios_strings()
+        android_keys = self._grep_android_strings()
+
+        total_grepped = core_keys | ios_keys | android_keys
+
+        print(f"Total strings grepped: {len(total_grepped)} - core: {len(core_keys)}, iOS: {len(ios_keys)}, android: {len(android_keys)}")
+
+        all_keys = set()
+        # Collect all keys from twine_file
+        for section in self.twine_file.sections:
+            for definition in section.definitions:
+                all_keys.add(definition.key)
+
+        unused = all_keys - total_grepped
+        if len(unused):
+            print(f"Found {len(unused)} definitions/keys which are no longer used in the codebase:")
+            print(*unused, sep="\n")
+            raise Exception("Unused definitions found")
+        else:
+            print("All good. There are no unused translation definitions/keys.")
+        return len(unused)
+
+    def _grep_core_strings(self) -> Set[str]:
+        if self.options['core_src_root'] is None:
+            return set()
+        return grep_folder(self.options['core_src_root'], ["*.h", "*.hpp", "*.cpp"], CORE_RE)
+
+    def _grep_ios_strings(self) -> Set[str]:
+        if self.options['ios_src_root'] is None:
+            return set()
+        root_path = self.options['ios_src_root']
+        return grep_folder(root_path, ["*.m", "*.mm", "*.swift", "*.h"], IOS_RE) | \
+               grep_folder(root_path, ["*.m", "*.mm", "*.swift", "*.h"], IOS_NS_RE) | \
+               grep_folder(root_path, ["*.m", "*.mm", "*.swift", "*.h"], IOS_XML_RE)
+
+    def _grep_android_strings(self) -> Set[str]:
+        if self.options['android_src_root'] is None:
+            return set()
+        root_path = self.options['android_src_root']
+        return grep_folder(root_path, ["*.java"], ANDROID_JAVA_RE) | \
+               grep_folder(root_path, ["*.java"], ANDROID_JAVA_PLURAL_RE) | \
+               grep_folder(root_path, ["*.xml"],  ANDROID_XML_RE)
 
     def _get_formatter(self):
         """Get the appropriate formatter based on options."""

--- a/python_twine/twine/runner.py
+++ b/python_twine/twine/runner.py
@@ -367,6 +367,7 @@ class Runner:
             for definition in section.definitions:
                 all_keys.add(definition.key)
 
+        # Compare collected keys
         unused = all_keys - total_grepped
         if len(unused):
             print(f"Found {len(unused)} definitions/keys which are no longer used in the codebase:")
@@ -377,11 +378,13 @@ class Runner:
         return len(unused)
 
     def _grep_core_strings(self) -> Set[str]:
+        # Search for localized strings in C++ source code.
         if self.options['core_src_root'] is None:
             return set()
         return grep_folder(self.options['core_src_root'], ["*.h", "*.hpp", "*.cpp"], CORE_RE)
 
     def _grep_ios_strings(self) -> Set[str]:
+        # Search for localized strings in iOS source code.
         if self.options['ios_src_root'] is None:
             return set()
         root_path = self.options['ios_src_root']
@@ -390,6 +393,7 @@ class Runner:
                grep_folder(root_path, ["*.m", "*.mm", "*.swift", "*.h"], IOS_XML_RE)
 
     def _grep_android_strings(self) -> Set[str]:
+        # Search for localized strings in Android source code and resources.
         if self.options['android_src_root'] is None:
             return set()
         root_path = self.options['android_src_root']

--- a/python_twine/twine/tools/grep.py
+++ b/python_twine/twine/tools/grep.py
@@ -3,16 +3,33 @@ from typing import Set, List, Iterable
 from glob import glob
 
 def grep_folder(path:str, files_patterns:List[str], search_regex:re.Pattern) -> Set[str]:
+    """
+    Scan directory for files in `path` directory by files pattern (e.g. "*.cpp", "*.swift")
+    and scans each files with search_regex to extract all matches.
+    """
     keys = set()
     for filepath in find_files_recursive(path, files_patterns):
         keys.update(find_keys_in_file(path + "/" + filepath, search_regex))
     return keys
 
 def find_files_recursive(root_path:str, files_patterns:List[str]) -> Iterable[str]:
+    """
+    Scan directory for files matching patterns. Patterns expected in format "*.java", "strings.xml", etc.
+
+    :return: relative files paths.
+    """
     for pttrn in files_patterns:
         yield from glob(f"**/{pttrn}", root_dir=root_path, recursive=True)
 
 def find_keys_in_file(filepath:str, search_regex:re.Pattern)->List[str]:
+    """
+    Scan file at `filepath` using regexp. All groups found by `search_regex` are merged
+    to result list.
+
+    :param filepath: path to text file
+    :param search_regex: pattern to search source code for a string key
+    :return: list of found keys
+    """
     try:
         keys = []
         for line in open(filepath, "r"):

--- a/python_twine/twine/tools/grep.py
+++ b/python_twine/twine/tools/grep.py
@@ -18,7 +18,7 @@ def find_keys_in_file(filepath:str, search_regex:re.Pattern)->List[str]:
         for line in open(filepath, "r"):
             m = search_regex.search(line)
             if m is not None:
-                keys += m.groups()
+                keys += [k for k in m.groups() if k is not None]
         return keys
     except UnicodeDecodeError:
         return []

--- a/python_twine/twine/tools/grep.py
+++ b/python_twine/twine/tools/grep.py
@@ -1,0 +1,24 @@
+import re
+from typing import Set, List, Iterable
+from glob import glob
+
+def grep_folder(path:str, files_patterns:List[str], search_regex:re.Pattern) -> Set[str]:
+    keys = set()
+    for filepath in find_files_recursive(path, files_patterns):
+        keys.update(find_keys_in_file(path + "/" + filepath, search_regex))
+    return keys
+
+def find_files_recursive(root_path:str, files_patterns:List[str]) -> Iterable[str]:
+    for pttrn in files_patterns:
+        yield from glob(f"**/{pttrn}", root_dir=root_path, recursive=True)
+
+def find_keys_in_file(filepath:str, search_regex:re.Pattern)->List[str]:
+    try:
+        keys = []
+        for line in open(filepath, "r"):
+            m = search_regex.search(line)
+            if m is not None:
+                keys += m.groups()
+        return keys
+    except UnicodeDecodeError:
+        return []


### PR DESCRIPTION
Added new CLI command `validate-unused-strings`. Usage:

```bash
python twine_cli.py validate-unused-strings \
    $OMAPS_REPO/data/strings/strings.txt
    --android-src-root $OMAPS_REPO/android
    --core-src-root $OMAPS_REPO/libs
    --ios-src-root $OMAPS_REPO/iphone
```

It scans source code in *.java, *.xml, *.h, *.cpp, *.m, *.mm, *.swift, *.xib files in search of localized strings patterns.

For latest `master` branch of OrganicMaps it found 56 unused strings:

| Usused key |
| --- |
| `NSLocationAlwaysUsageDescription` |
| `NSLocationWhenInUseUsageDescription` |
| `blue` |
| `blue_gray` |
| `bookmarks_new_list_hint` |
| `brown` |
| `category_bank` |
| `category_children` |
| `category_entertainment` |
| `category_hospital` |
| `category_nightlife` |
| `category_pharmacy` |
| `category_police` |
| `category_post` |
| `category_recycling` |
| `category_secondhand` |
| `category_tourism` |
| `category_transport` |
| `category_water` |
| `clear_the_search` |
| `continue_recording` |
| `cyan` |
| `deep_orange` |
| `deep_purple` |
| `dialog_routing_rebuild_for_vehicle_carplay` |
| `editor_add_select_category_popular_subtitle` |
| `editor_login_error_dialog` |
| `elevation_profile_distance` |
| `elevation_profile_time` |
| `gray` |
| `green` |
| `kilometers_per_hour` |
| `last_upload` |
| `light_blue` |
| `lime` |
| `login_osm_browser` |
| `login_osm_credentials` |
| `miles_per_hour` |
| `my_position_share_email` |
| `my_position_share_sms` |
| `nav_auto` |
| `orange` |
| `password_8_chars_min` |
| `pink` |
| `planning_route_remove_title` |
| `purple` |
| `red` |
| `route` |
| `routing_arrive` |
| `start_from_my_position` |
| `stop_without_saving` |
| `switch_to_phone_bookmarks_carplay` |
| `teal` |
| `track_recording_alert_title` |
| `yellow` |
| `you` |