### PR TITLE
[fallback] Map yue-HK and yue-MO to yue

### DIFF
--- a/python_twine/twine/output_processor.py
+++ b/python_twine/twine/output_processor.py
@@ -36,6 +36,9 @@ class OutputProcessor:
         fallback_mapping = {
             "zh-CN": "zh-Hans",  # Chinese Simplified
             "zh-TW": "zh-Hant",  # Chinese Traditional
+            # 3-letter language codes don't match the regex below, so map explicitly.
+            "yue-HK": "yue",  # Cantonese (Hong Kong)
+            "yue-MO": "yue",  # Cantonese (Macau)
         }
 
         fallbacks = []


### PR DESCRIPTION
The 3-letter language code "yue" doesn't match the existing dialect fallback regex, so add explicit fallback_mapping entries. This lets sound.txt (in the consumer repo) define Cantonese translations once under "yue =" and have yue-HK / yue-MO inherit them via fallback.