### PR TITLE
[qt] Add Qt ID-based TS formatter with plural support

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ Twine currently supports the following output formats:
 * [Django PO Files][djangopo] (format: django)
 * [Tizen String Resources][tizen] (format: tizen)
 * [Flash/Flex Properties][flash] (format: flash)
+* [Qt Linguist TS Files][qtts] (format: qt) — _python_twine only_
+    * ID-based `<message id="…">` messages for `qtTrId()` lookup.
+    * Numerus (plural) support via Qt's positional `<numerusform>` rules.
+    * Definition comments emitted as `<extracomment>` for translators.
 
 If you would like to enable Twine to create localization files in another format, read the wiki page on how to create an appropriate formatter.
 
@@ -281,4 +285,5 @@ Many thanks to all of the contributors to the Twine project, including:
 [djangopo]: https://docs.djangoproject.com/en/dev/topics/i18n/translation/
 [tizen]: https://developer.tizen.org/documentation/articles/localization
 [flash]: http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/mx/resources/IResourceManager.html#getString()
+[qtts]: https://doc.qt.io/qt-6/linguist-ts-file-format.html
 [printf]: https://en.wikipedia.org/wiki/Printf_format_string

--- a/python_twine/tests/test_formatter_qt.py
+++ b/python_twine/tests/test_formatter_qt.py
@@ -1,0 +1,343 @@
+"""
+Tests for the Qt ID-based TS formatter (non-plural messages).
+"""
+
+import io
+
+import pytest
+
+from twine import TwineError
+from twine.formatters.qt import QtFormatter
+from twine.twine_file import TwineFile, TwineSection, TwineDefinition
+
+
+@pytest.fixture
+def formatter():
+    twine_file = TwineFile()
+    formatter = QtFormatter()
+    formatter.twine_file = twine_file
+    formatter.options = {"consume_all": True, "consume_comments": True}
+    return formatter
+
+
+def _make_simple_twine_file() -> TwineFile:
+    twine_file = TwineFile()
+    twine_file.language_codes = ["en", "ru"]
+    section = TwineSection("General")
+    twine_file.sections.append(section)
+
+    back = TwineDefinition("back")
+    back.translations["en"] = "Back"
+    back.translations["ru"] = "Назад"
+    twine_file.definitions_by_key["back"] = back
+    section.definitions.append(back)
+
+    return twine_file
+
+
+class TestQtFormatterBasics:
+    def test_format_name(self, formatter):
+        assert formatter.format_name() == "qt"
+        assert formatter.extension() == ".ts"
+        assert formatter.default_file_name() == "omim.ts"
+
+    def test_output_path_for_language(self, formatter):
+        assert formatter.output_path_for_language("ru") == "ru"
+        assert formatter.output_path_for_language("zh-Hans") == "zh-Hans"
+
+
+class TestQtFormatterWrite:
+    def test_simple_strings(self, formatter):
+        formatter.twine_file = _make_simple_twine_file()
+
+        en_output = formatter.format_file("en")
+        assert en_output == (
+            '<?xml version="1.0" encoding="utf-8"?>\n'
+            '<TS version="2.1" language="en">\n'
+            '<context>\n<name></name>\n'
+            '<message id="back">\n'
+            '<source>Back</source>\n'
+            '<translation>Back</translation>\n'
+            '</message>\n'
+            '</context>\n'
+            '</TS>\n'
+        )
+
+        ru_output = formatter.format_file("ru")
+        assert ru_output == (
+            '<?xml version="1.0" encoding="utf-8"?>\n'
+            '<TS version="2.1" language="ru">\n'
+            '<context>\n<name></name>\n'
+            '<message id="back">\n'
+            '<source>Back</source>\n'
+            '<translation>Назад</translation>\n'
+            '</message>\n'
+            '</context>\n'
+            '</TS>\n'
+        )
+
+    def test_placeholder_conversion_sequential(self, formatter):
+        twine_file = TwineFile()
+        twine_file.language_codes = ["en"]
+        section = TwineSection("Routing")
+        twine_file.sections.append(section)
+
+        download = TwineDefinition("download_country_failed")
+        download.translations["en"] = "%@ download has failed"
+        twine_file.definitions_by_key["download_country_failed"] = download
+        section.definitions.append(download)
+
+        share = TwineDefinition("my_position_share_sms")
+        share.translations["en"] = "Check %@ or %@ for more"
+        twine_file.definitions_by_key["my_position_share_sms"] = share
+        section.definitions.append(share)
+
+        formatter.twine_file = twine_file
+        output = formatter.format_file("en")
+
+        assert "<translation>%1 download has failed</translation>" in output
+        assert "<translation>Check %1 or %2 for more</translation>" in output
+
+    def test_placeholder_conversion_numbered_preserved(self, formatter):
+        twine_file = TwineFile()
+        twine_file.language_codes = ["en"]
+        section = TwineSection("Messages")
+        twine_file.sections.append(section)
+
+        msg = TwineDefinition("info_message")
+        msg.translations["en"] = "First %1$@, then %2$@, finally %1$@"
+        twine_file.definitions_by_key["info_message"] = msg
+        section.definitions.append(msg)
+
+        formatter.twine_file = twine_file
+        output = formatter.format_file("en")
+        assert "<translation>First %1, then %2, finally %1</translation>" in output
+
+    def test_newlines_preserved(self, formatter):
+        twine_file = TwineFile()
+        twine_file.language_codes = ["en"]
+        section = TwineSection("Misc")
+        twine_file.sections.append(section)
+
+        d = TwineDefinition("wait_message")
+        d.translations["en"] = "This can take several minutes.\\nPlease wait…"
+        twine_file.definitions_by_key["wait_message"] = d
+        section.definitions.append(d)
+
+        formatter.twine_file = twine_file
+        output = formatter.format_file("en")
+        assert (
+            "<translation>This can take several minutes.\n"
+            "Please wait…</translation>"
+        ) in output
+
+    def test_xml_special_chars_escaped(self, formatter):
+        twine_file = TwineFile()
+        twine_file.language_codes = ["en"]
+        section = TwineSection("Misc")
+        twine_file.sections.append(section)
+
+        d = TwineDefinition("ampersand_test")
+        d.translations["en"] = 'Tom & Jerry <fast> "go"'
+        twine_file.definitions_by_key["ampersand_test"] = d
+        section.definitions.append(d)
+
+        formatter.twine_file = twine_file
+        output = formatter.format_file("en")
+        assert (
+            '<translation>Tom &amp; Jerry &lt;fast&gt; &quot;go&quot;</translation>'
+        ) in output
+
+    def test_boundary_spaces_escaped(self, formatter):
+        twine_file = TwineFile()
+        twine_file.language_codes = ["en"]
+        section = TwineSection("Misc")
+        twine_file.sections.append(section)
+
+        d = TwineDefinition("padded")
+        d.translations["en"] = "  hello  "
+        twine_file.definitions_by_key["padded"] = d
+        section.definitions.append(d)
+
+        formatter.twine_file = twine_file
+        output = formatter.format_file("en")
+        assert "<translation>&#32;&#32;hello&#32;&#32;</translation>" in output
+
+    def test_source_uses_developer_language(self, formatter):
+        """`<source>` always carries the developer-language string regardless
+        of the target translation language."""
+        twine_file = TwineFile()
+        twine_file.language_codes = ["en", "ru"]  # en is developer language
+        section = TwineSection("General")
+        twine_file.sections.append(section)
+
+        back = TwineDefinition("back")
+        back.translations["en"] = "Back"
+        back.translations["ru"] = "Назад"
+        twine_file.definitions_by_key["back"] = back
+        section.definitions.append(back)
+
+        formatter.twine_file = twine_file
+        output = formatter.format_file("ru")
+        assert "<source>Back</source>" in output
+        assert "<translation>Назад</translation>" in output
+
+    def test_empty_section_skipped(self, formatter):
+        twine_file = TwineFile()
+        twine_file.language_codes = ["en", "ru"]
+        empty = TwineSection("Empty")
+        twine_file.sections.append(empty)
+
+        present = TwineSection("Present")
+        twine_file.sections.append(present)
+
+        d = TwineDefinition("hello")
+        d.translations["en"] = "Hi"
+        twine_file.definitions_by_key["hello"] = d
+        present.definitions.append(d)
+
+        formatter.twine_file = twine_file
+        output = formatter.format_file("en")
+        # Only one <context> block emitted (the empty section is omitted).
+        assert output.count("<context>") == 1
+
+    def test_single_context_wraps_multiple_sections(self, formatter):
+        """All sections share one <context> block (qtTrId ignores name and
+        Qt's TS schema prefers one context per file)."""
+        twine_file = TwineFile()
+        twine_file.language_codes = ["en"]
+
+        section_a = TwineSection("A")
+        twine_file.sections.append(section_a)
+        d1 = TwineDefinition("a_key")
+        d1.translations["en"] = "A value"
+        twine_file.definitions_by_key["a_key"] = d1
+        section_a.definitions.append(d1)
+
+        section_b = TwineSection("B")
+        twine_file.sections.append(section_b)
+        d2 = TwineDefinition("b_key")
+        d2.translations["en"] = "B value"
+        twine_file.definitions_by_key["b_key"] = d2
+        section_b.definitions.append(d2)
+
+        formatter.twine_file = twine_file
+        output = formatter.format_file("en")
+        assert output.count("<context>") == 1
+        assert output.count("</context>") == 1
+        assert 'id="a_key"' in output
+        assert 'id="b_key"' in output
+
+    def test_comment_emitted_as_extracomment(self, formatter):
+        twine_file = TwineFile()
+        twine_file.language_codes = ["en"]
+        section = TwineSection("General")
+        twine_file.sections.append(section)
+
+        d = TwineDefinition("back")
+        d.translations["en"] = "Back"
+        d.comment = "Navigation back action"
+        twine_file.definitions_by_key["back"] = d
+        section.definitions.append(d)
+
+        formatter.twine_file = twine_file
+        output = formatter.format_file("en")
+        assert "<extracomment>Navigation back action</extracomment>" in output
+
+    def test_extracomment_xml_escaped(self, formatter):
+        twine_file = TwineFile()
+        twine_file.language_codes = ["en"]
+        section = TwineSection("General")
+        twine_file.sections.append(section)
+
+        d = TwineDefinition("warn")
+        d.translations["en"] = "Warning"
+        d.comment = 'Use for "soft" warnings & alerts'
+        twine_file.definitions_by_key["warn"] = d
+        section.definitions.append(d)
+
+        formatter.twine_file = twine_file
+        output = formatter.format_file("en")
+        assert "<extracomment>Use for &quot;soft&quot; warnings &amp; alerts</extracomment>" in output
+
+    def test_missing_comment_omits_extracomment(self, formatter):
+        formatter.twine_file = _make_simple_twine_file()
+        output = formatter.format_file("en")
+        assert "<extracomment>" not in output
+
+    def test_boundary_tabs_escaped(self, formatter):
+        twine_file = TwineFile()
+        twine_file.language_codes = ["en"]
+        section = TwineSection("Misc")
+        twine_file.sections.append(section)
+
+        d = TwineDefinition("tabbed")
+        d.translations["en"] = "\thello\t"
+        twine_file.definitions_by_key["tabbed"] = d
+        section.definitions.append(d)
+
+        formatter.twine_file = twine_file
+        output = formatter.format_file("en")
+        assert "<translation>&#9;hello&#9;</translation>" in output
+
+    def test_boundary_nbsp_escaped(self, formatter):
+        twine_file = TwineFile()
+        twine_file.language_codes = ["en"]
+        section = TwineSection("Misc")
+        twine_file.sections.append(section)
+
+        d = TwineDefinition("nbsp_pad")
+        d.translations["en"] = " word "
+        twine_file.definitions_by_key["nbsp_pad"] = d
+        section.definitions.append(d)
+
+        formatter.twine_file = twine_file
+        output = formatter.format_file("en")
+        assert "<translation>&#160;word&#160;</translation>" in output
+
+
+class TestQtFormatterRead:
+    def test_read_simple(self, formatter):
+        ts = (
+            '<?xml version="1.0" encoding="utf-8"?>\n'
+            '<TS version="2.1" language="ru">\n'
+            '<context>\n<name></name>\n'
+            '<message id="back">\n'
+            '<source>Back</source>\n'
+            '<translation>Назад</translation>\n'
+            '</message>\n'
+            '<message id="cancel">\n'
+            '<source>Cancel</source>\n'
+            '<translation>Отмена</translation>\n'
+            '</message>\n'
+            '</context>\n'
+            '</TS>\n'
+        )
+        formatter.read(io.StringIO(ts), "ru")
+        twine_file = formatter.twine_file
+        assert twine_file.definitions_by_key["back"].translations["ru"] == "Назад"
+        assert twine_file.definitions_by_key["cancel"].translations["ru"] == "Отмена"
+
+    def test_read_skips_numerus(self, formatter):
+        """Plural messages are not consumed (lossy round-trip)."""
+        ts = (
+            '<?xml version="1.0" encoding="utf-8"?>\n'
+            '<TS version="2.1" language="en">\n'
+            '<context>\n<name></name>\n'
+            '<message id="tracks" numerus="yes">\n'
+            '<source>%n tracks</source>\n'
+            '<translation>\n'
+            '<numerusform>%n track</numerusform>\n'
+            '<numerusform>%n tracks</numerusform>\n'
+            '</translation>\n'
+            '</message>\n'
+            '</context>\n'
+            '</TS>\n'
+        )
+        formatter.read(io.StringIO(ts), "en")
+        # The plural definition is not created during read.
+        assert "tracks" not in formatter.twine_file.definitions_by_key
+
+    def test_read_malformed_xml_raises(self, formatter):
+        with pytest.raises(TwineError, match="Failed to parse Qt TS"):
+            formatter.read(io.StringIO("<TS>not closed"), "en")

--- a/python_twine/tests/test_formatter_qt_plural.py
+++ b/python_twine/tests/test_formatter_qt_plural.py
@@ -1,0 +1,363 @@
+"""
+Tests for the Qt formatter's plural (numerus) message handling.
+"""
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from twine import TwineError
+from twine.formatters.qt import QtFormatter
+from twine.formatters.qt_plural_rules import (
+    QT_NUMERUS_FORMS,
+    get_qt_numerus_forms,
+)
+from twine.twine_file import TwineFile, TwineSection, TwineDefinition
+
+
+@pytest.fixture
+def formatter():
+    twine_file = TwineFile()
+    formatter = QtFormatter()
+    formatter.twine_file = twine_file
+    formatter.options = {"consume_all": True, "consume_comments": True}
+    return formatter
+
+
+def _set_plural(definition: TwineDefinition, lang: str, forms: dict):
+    """Mirror how the strings.txt parser populates a plural: store both
+    plural_translations[lang] and translations[lang] (=other or first form)."""
+    definition.plural_translations[lang] = forms
+    if "other" in forms:
+        definition.translations[lang] = forms["other"]
+    elif forms:
+        definition.translations[lang] = next(iter(forms.values()))
+
+
+def _tracks_twine_file() -> TwineFile:
+    """Mirrors the [tracks] entry in OM's strings.txt at the time of writing."""
+    twine_file = TwineFile()
+    twine_file.language_codes = ["en", "ru", "ar", "ja", "fr", "uk"]
+    section = TwineSection("Bookmarks")
+    twine_file.sections.append(section)
+
+    tracks = TwineDefinition("tracks")
+    _set_plural(tracks, "en", {"one": "%d track", "other": "%d tracks"})
+    _set_plural(tracks, "ru", {
+        "one": "%d трек", "few": "%d трека",
+        "many": "%d треков", "other": "%d трека",
+    })
+    _set_plural(tracks, "ar", {
+        "zero": "%d مسار", "one": "%d مسار", "two": "%d مساران",
+        "few": "%d مسارات", "many": "%d مسارا", "other": "%d مسار",
+    })
+    _set_plural(tracks, "ja", {"other": "%d トラック"})
+    _set_plural(tracks, "fr", {"one": "%d piste", "other": "%d pistes"})
+    _set_plural(tracks, "uk", {
+        "one": "%d трек", "few": "%d треки", "many": "%d треків"
+    })
+
+    twine_file.definitions_by_key["tracks"] = tracks
+    section.definitions.append(tracks)
+    return twine_file
+
+
+class TestPluralRulesTable:
+    def test_table_covers_common_languages(self):
+        """Sanity check on the derived table from numerus.cpp."""
+        assert QT_NUMERUS_FORMS["en"] == ["one", "other"]
+        assert QT_NUMERUS_FORMS["ru"] == ["one", "few", "many"]
+        assert QT_NUMERUS_FORMS["ar"] == ["zero", "one", "two", "few", "many", "other"]
+        assert QT_NUMERUS_FORMS["ja"] == ["other"]
+        assert QT_NUMERUS_FORMS["fr"] == ["one", "other"]
+        assert QT_NUMERUS_FORMS["pl"] == ["one", "few", "many"]
+        assert QT_NUMERUS_FORMS["cs"] == ["one", "few", "other"]
+        assert QT_NUMERUS_FORMS["sk"] == ["one", "few", "other"]
+        assert QT_NUMERUS_FORMS["ro"] == ["one", "few", "other"]
+        assert QT_NUMERUS_FORMS["sl"] == ["one", "two", "few", "other"]
+        assert QT_NUMERUS_FORMS["lv"] == ["one", "other", "zero"]
+
+    def test_region_fallback(self):
+        assert get_qt_numerus_forms("es-MX") == ["one", "other"]
+        assert get_qt_numerus_forms("en-GB") == ["one", "other"]
+        assert get_qt_numerus_forms("fr-CA") == ["one", "other"]
+
+    def test_pt_br_overrides_pt(self):
+        """Brazilian Portuguese uses french-style rule (n <= 1 → one); the
+        positional shape is the same as english style, but Qt internally
+        applies different selection rules."""
+        assert get_qt_numerus_forms("pt") == ["one", "other"]
+        assert get_qt_numerus_forms("pt-BR") == ["one", "other"]
+
+    def test_chinese_variants(self):
+        assert get_qt_numerus_forms("zh-Hans") == ["other"]
+        assert get_qt_numerus_forms("zh-Hant") == ["other"]
+        assert get_qt_numerus_forms("zh") == ["other"]
+
+    def test_unknown_language_returns_none(self):
+        assert get_qt_numerus_forms("xx") is None
+
+
+class TestPluralWrite:
+    def test_english_two_forms(self, formatter):
+        formatter.twine_file = _tracks_twine_file()
+        output = formatter.format_file("en")
+        assert '<message id="tracks" numerus="yes">' in output
+        assert "<source>%n tracks</source>" in output
+        assert (
+            "<translation>\n"
+            "<numerusform>%n track</numerusform>\n"
+            "<numerusform>%n tracks</numerusform>\n"
+            "</translation>"
+        ) in output
+
+    def test_russian_three_forms_drops_cldr_other(self, formatter):
+        formatter.twine_file = _tracks_twine_file()
+        output = formatter.format_file("ru")
+        # Russian uses one/few/many positionally — CLDR 'other' is discarded.
+        assert (
+            "<translation>\n"
+            "<numerusform>%n трек</numerusform>\n"
+            "<numerusform>%n трека</numerusform>\n"
+            "<numerusform>%n треков</numerusform>\n"
+            "</translation>"
+        ) in output
+
+    def test_arabic_six_forms(self, formatter):
+        formatter.twine_file = _tracks_twine_file()
+        output = formatter.format_file("ar")
+        # zero, one, two, few, many, other — six forms in positional order.
+        assert output.count("<numerusform>") == 6
+        assert "<numerusform>%n مسار</numerusform>" in output  # zero
+        assert "<numerusform>%n مساران</numerusform>" in output  # two
+        assert "<numerusform>%n مسارات</numerusform>" in output  # few
+
+    def test_japanese_universal_form_only(self, formatter):
+        formatter.twine_file = _tracks_twine_file()
+        output = formatter.format_file("ja")
+        assert output.count("<numerusform>") == 1
+        assert "<numerusform>%n トラック</numerusform>" in output
+
+    def test_uk_per_form_fallback_uses_developer_other(self, formatter):
+        """Ukrainian strings.txt provides one/few/many. The Qt-uk table is
+        ['one', 'few', 'many'] so no fallback needed; this checks that we
+        don't accidentally insert a 4th form."""
+        formatter.twine_file = _tracks_twine_file()
+        output = formatter.format_file("uk")
+        assert output.count("<numerusform>") == 3
+        assert "<numerusform>%n трек</numerusform>" in output
+
+    def test_french_two_forms(self, formatter):
+        formatter.twine_file = _tracks_twine_file()
+        output = formatter.format_file("fr")
+        assert output.count("<numerusform>") == 2
+        assert "<numerusform>%n piste</numerusform>" in output
+        assert "<numerusform>%n pistes</numerusform>" in output
+
+    def test_source_from_developer_other_form(self, formatter):
+        """`<source>` is the developer-language 'other' form, with %d → %n."""
+        formatter.twine_file = _tracks_twine_file()
+        for lang in ["en", "ru", "ar", "ja", "fr"]:
+            output = formatter.format_file(lang)
+            assert "<source>%n tracks</source>" in output
+
+
+class TestPluralFallback:
+    def test_missing_form_falls_back_to_translated_other(self, formatter):
+        twine_file = TwineFile()
+        twine_file.language_codes = ["en", "ru"]
+        section = TwineSection("Bookmarks")
+        twine_file.sections.append(section)
+
+        d = TwineDefinition("partial")
+        _set_plural(d, "en", {"one": "%d edit", "other": "%d edits"})
+        # Russian has only 'other' — 'one' and 'few' should fall back to 'other'.
+        _set_plural(d, "ru", {"other": "%d правок"})
+        twine_file.definitions_by_key["partial"] = d
+        section.definitions.append(d)
+
+        formatter.twine_file = twine_file
+        output = formatter.format_file("ru")
+        # All three Russian positional forms should be the translated 'other'.
+        assert (
+            "<numerusform>%n правок</numerusform>\n"
+            "<numerusform>%n правок</numerusform>\n"
+            "<numerusform>%n правок</numerusform>"
+        ) in output
+
+    def test_missing_language_falls_back_to_developer_other(self, formatter):
+        twine_file = TwineFile()
+        twine_file.language_codes = ["en", "ru"]
+        section = TwineSection("Bookmarks")
+        twine_file.sections.append(section)
+
+        d = TwineDefinition("untranslated")
+        _set_plural(d, "en", {"one": "%d edit", "other": "%d edits"})
+        # Russian has no plural data at all — fall back through dev lang.
+        twine_file.definitions_by_key["untranslated"] = d
+        section.definitions.append(d)
+        # include=all triggers OutputProcessor to fill missing target with dev fallback
+        formatter.options = {**formatter.options, "include": "all"}
+
+        formatter.twine_file = twine_file
+        output = formatter.format_file("ru")
+        # Each of the 3 Russian positional slots resolves via the dev-lang
+        # chain. 'one' matches; 'few' and 'many' fall back to dev-lang 'other'.
+        assert "<numerusform>%n edit</numerusform>" in output  # one
+        assert output.count("<numerusform>%n edits</numerusform>") == 2  # few + many
+
+    def test_unknown_language_raises(self, formatter):
+        twine_file = TwineFile()
+        twine_file.language_codes = ["en", "xx"]
+        section = TwineSection("Bookmarks")
+        twine_file.sections.append(section)
+
+        d = TwineDefinition("foo")
+        _set_plural(d, "en", {"one": "%d edit", "other": "%d edits"})
+        _set_plural(d, "xx", {"one": "uno", "other": "many"})
+        twine_file.definitions_by_key["foo"] = d
+        section.definitions.append(d)
+
+        formatter.twine_file = twine_file
+        with pytest.raises(TwineError, match="Qt has no plural rule for language 'xx'"):
+            formatter.format_file("xx")
+
+    def test_per_form_placeholder_difference_allowed(self, formatter):
+        """Real translations sometimes drop the count in certain forms — e.g.,
+        Arabic's 'zero' form ('no files were found') has no %n while non-zero
+        forms do. Qt accepts this; we don't enforce per-form consistency."""
+        twine_file = TwineFile()
+        twine_file.language_codes = ["en", "ar"]
+        section = TwineSection("Bookmarks")
+        twine_file.sections.append(section)
+
+        d = TwineDefinition("found")
+        _set_plural(d, "en", {"one": "%d file found", "other": "%d files found"})
+        _set_plural(d, "ar", {
+            "zero": "no files",
+            "one": "%d file",
+            "two": "%d files",
+            "few": "%d files",
+            "many": "%d files",
+            "other": "%d files",
+        })
+        twine_file.definitions_by_key["found"] = d
+        section.definitions.append(d)
+
+        formatter.twine_file = twine_file
+        output = formatter.format_file("ar")
+        assert "<numerusform>no files</numerusform>" in output
+        assert "<numerusform>%n file</numerusform>" in output
+
+
+class TestPluralPlaceholderConversion:
+    def test_first_numeric_becomes_n(self, formatter):
+        """The first numeric placeholder is rewritten to %n; other
+        placeholders remain sequentially numbered from %1."""
+        twine_file = TwineFile()
+        twine_file.language_codes = ["en"]
+        section = TwineSection("Misc")
+        twine_file.sections.append(section)
+
+        d = TwineDefinition("multi")
+        _set_plural(d, "en", {
+            "one": "%d file at %@",
+            "other": "%d files at %@",
+        })
+        twine_file.definitions_by_key["multi"] = d
+        section.definitions.append(d)
+
+        formatter.twine_file = twine_file
+        output = formatter.format_file("en")
+        assert "<numerusform>%n file at %1</numerusform>" in output
+        assert "<numerusform>%n files at %1</numerusform>" in output
+
+    def test_no_numeric_placeholder_is_ok(self, formatter):
+        """A plural without any count-eligible placeholder generates a
+        numerus message anyway (every form just has zero %n's). Qt still
+        picks the right form by n, just won't substitute the number."""
+        twine_file = TwineFile()
+        twine_file.language_codes = ["en"]
+        section = TwineSection("Misc")
+        twine_file.sections.append(section)
+
+        d = TwineDefinition("descriptive")
+        _set_plural(d, "en", {
+            "one": "one item",
+            "other": "many items",
+        })
+        twine_file.definitions_by_key["descriptive"] = d
+        section.definitions.append(d)
+
+        formatter.twine_file = twine_file
+        output = formatter.format_file("en")
+        assert "<numerusform>one item</numerusform>" in output
+        assert "<numerusform>many items</numerusform>" in output
+
+
+@pytest.mark.skipif(shutil.which("lrelease") is None, reason="lrelease is not installed")
+class TestLreleaseCompilation:
+    """Compile generated TS through Qt's lrelease to catch schema or
+    encoding regressions that pure XML assertions miss. Skipped in
+    environments without Qt installed."""
+
+    @staticmethod
+    def _compile(ts_content: str) -> tuple[int, str]:
+        with tempfile.TemporaryDirectory() as tmp:
+            ts_path = Path(tmp) / "test.ts"
+            qm_path = Path(tmp) / "test.qm"
+            ts_path.write_text(ts_content, encoding="utf-8")
+            result = subprocess.run(
+                ["lrelease", str(ts_path), "-qm", str(qm_path)],
+                capture_output=True, text=True,
+            )
+            combined = (result.stderr + result.stdout).lower()
+            return result.returncode, combined
+
+    def _assert_clean(self, output: str) -> None:
+        rc, msg = self._compile(output)
+        assert rc == 0, msg
+        assert "warning" not in msg, msg
+        assert "error" not in msg, msg
+
+    def test_compiles_english_plural(self, formatter):
+        formatter.twine_file = _tracks_twine_file()
+        self._assert_clean(formatter.format_file("en"))
+
+    def test_compiles_russian_plural(self, formatter):
+        formatter.twine_file = _tracks_twine_file()
+        self._assert_clean(formatter.format_file("ru"))
+
+    def test_compiles_arabic_plural(self, formatter):
+        formatter.twine_file = _tracks_twine_file()
+        self._assert_clean(formatter.format_file("ar"))
+
+    def test_compiles_japanese_plural(self, formatter):
+        formatter.twine_file = _tracks_twine_file()
+        self._assert_clean(formatter.format_file("ja"))
+
+    def test_compiles_with_extracomment_and_boundary_whitespace(self, formatter):
+        """Mixed-feature smoke test: extracomment + tab-bounded translation +
+        plural in the same context block."""
+        twine_file = TwineFile()
+        twine_file.language_codes = ["en"]
+        section = TwineSection("Mixed")
+        twine_file.sections.append(section)
+
+        plain = TwineDefinition("plain")
+        plain.translations["en"] = "\tIndented\t"
+        plain.comment = "Has leading & trailing tabs"
+        twine_file.definitions_by_key["plain"] = plain
+        section.definitions.append(plain)
+
+        plural = TwineDefinition("count")
+        _set_plural(plural, "en", {"one": "%d item", "other": "%d items"})
+        plural.comment = "Item counter"
+        twine_file.definitions_by_key["count"] = plural
+        section.definitions.append(plural)
+
+        formatter.twine_file = twine_file
+        self._assert_clean(formatter.format_file("en"))

--- a/python_twine/tests/test_output_processor.py
+++ b/python_twine/tests/test_output_processor.py
@@ -136,3 +136,52 @@ class TestTranslationFallback:
         result = processor.process("de")
 
         assert result.definitions_by_key["key1"].translations["de"] == "value1-fr"
+
+
+class TestPluralEdgeCases:
+    """Regression tests for plural-definition handling that previously
+    raised KeyError / TypeError before the OutputProcessor fix."""
+
+    def test_include_translated_with_singular_target_does_not_raise(self):
+        """A plural definition whose target language has only a non-plural
+        translation must not raise under include='translated'. The plural
+        slot stays absent — the formatter then emits it as a regular message."""
+        twine_file = TwineFile()
+        twine_file.language_codes = ["en", "ja"]
+        section = TwineSection("Section")
+        twine_file.sections.append(section)
+
+        d = TwineDefinition("partial")
+        d.translations["en"] = "%d items"
+        d.translations["ja"] = "アイテム"
+        d.plural_translations["en"] = {"one": "%d item", "other": "%d items"}
+        twine_file.definitions_by_key["partial"] = d
+        section.definitions.append(d)
+
+        result = OutputProcessor(twine_file, {"include": "translated"}).process("ja")
+
+        processed = result.definitions_by_key["partial"]
+        assert processed.translations["ja"] == "アイテム"
+        assert "ja" not in processed.plural_translations
+
+    def test_no_plural_fallback_available_does_not_raise(self):
+        """When no fallback language has plural data, the OutputProcessor
+        must skip the plural augmentation rather than assigning None and
+        TypeError-ing on `"other" not in None`."""
+        twine_file = TwineFile()
+        twine_file.language_codes = ["en", "fr"]
+        section = TwineSection("Section")
+        twine_file.sections.append(section)
+
+        d = TwineDefinition("isolated")
+        d.translations["en"] = "items"
+        d.translations["fr"] = "éléments"
+        # Plural data only for a language that is not in fr's fallback chain.
+        d.plural_translations["es"] = {"one": "artículo", "other": "artículos"}
+        twine_file.definitions_by_key["isolated"] = d
+        section.definitions.append(d)
+
+        result = OutputProcessor(twine_file, {"include": "all"}).process("fr")
+
+        assert "isolated" in result.definitions_by_key
+        assert result.definitions_by_key["isolated"].translations["fr"] == "éléments"

--- a/python_twine/twine/cli.py
+++ b/python_twine/twine/cli.py
@@ -130,7 +130,7 @@ class CLI:
         parser.add_argument(
             "-f",
             "--format",
-            help="Localization file format (android, apple, gettext, jquery, django, tizen, flash)",
+            help="Localization file format (android, apple, gettext, jquery, django, tizen, flash, qt)",
         )
         parser.add_argument(
             "--tags",

--- a/python_twine/twine/formatters/qt.py
+++ b/python_twine/twine/formatters/qt.py
@@ -1,0 +1,320 @@
+"""
+Qt ID-based TS formatter (Qt Linguist source format).
+
+Emits files consumed by `lrelease` to produce .qm bundles, looked up at
+runtime via `qtTrId(id, n)`. Uses an empty <name></name> context — required
+by qtTrId for ID-based lookup. Supports numerus (plural) messages by
+mapping Twine's CLDR-named plural categories to Qt's positional
+<numerusform> entries via the table in qt_plural_rules.py.
+"""
+
+import html
+import re
+from typing import Dict, List, Optional, TextIO
+from xml.etree import ElementTree as ET
+
+from twine import TwineError
+from twine.formatters import AbstractFormatter
+from twine.formatters.qt_plural_rules import get_qt_numerus_forms
+from twine.placeholders import PLACEHOLDER_REGEX
+from twine.twine_file import TwineDefinition
+
+
+# A "count-eligible" placeholder consumes a numeric argument: %d, %i, %u,
+# %f, %1$d, %02d, etc. Qt's runtime substitutes the count argument from
+# qtTrId(id, n) into %n; the first such placeholder in the source becomes
+# %n during conversion.
+#
+# `s` (string) and `@` (Objective-C object) are deliberately omitted: in
+# Twine's source format these never represent the plural count argument,
+# so they should not be rewritten to %n.
+_NUMERIC_TYPES = set("diufFeEgGxXoaA")
+
+# Forms preferred as the source string for a plural definition, in order.
+_SOURCE_PLURAL_PREFERENCE = ("other", "one", "few", "many", "two", "zero")
+
+
+class QtFormatter(AbstractFormatter):
+    """Formatter for Qt ID-based .ts localization files."""
+
+    SUPPORTS_PLURAL = True
+
+    def format_name(self) -> str:
+        return "qt"
+
+    def extension(self) -> str:
+        return ".ts"
+
+    def default_file_name(self) -> str:
+        return "omim.ts"
+
+    def output_path_for_language(self, lang: str) -> str:
+        return lang
+
+    # ---- read --------------------------------------------------------------
+
+    def read(self, io: TextIO, lang: str):
+        """Parse Qt TS into the in-memory TwineFile. Plural messages are
+        currently not consumed — Qt's positional numerusforms are lossy to
+        round-trip back into CLDR-named categories, and no current pipeline
+        feeds Qt TS back to strings.txt."""
+        try:
+            root = ET.parse(io).getroot()
+        except ET.ParseError as e:
+            raise TwineError(f"Failed to parse Qt TS: {e}") from e
+
+        for message in root.iter("message"):
+            key = message.get("id")
+            if not key:
+                continue
+
+            translation = message.find("translation")
+            if translation is None or translation.find("numerusform") is not None:
+                continue
+
+            if translation.text is not None:
+                self.set_translation_for_key(key, lang, self._unformat_value(translation.text), section_name=None)
+
+    # ---- write -------------------------------------------------------------
+
+    def format_header(self, lang: str) -> str:
+        return f'<?xml version="1.0" encoding="utf-8"?>\n<TS version="2.1" language="{self._escape(lang)}">'
+
+    def format_file(self, lang: str) -> Optional[str]:
+        result = super().format_file(lang)
+        if result:
+            result += "\n</TS>\n"
+        return result
+
+    def format_sections(self, twine_file, lang: str) -> str:
+        """Emit a single <context> wrapping all messages from every section.
+        qtTrId() requires an empty Qt context for ID-based lookup, and one
+        context per file matches Qt's TS schema better than multiple empty
+        contexts."""
+        bodies = []
+        for section in twine_file.sections:
+            body = self.format_section(section, lang)
+            if body:
+                bodies.append(body)
+        if not bodies:
+            return ""
+        return "<context>\n<name></name>\n" + "\n".join(bodies) + "\n</context>"
+
+    def format_section(self, section, lang: str) -> Optional[str]:
+        definitions = [d for d in section.definitions if self.should_include_definition(d, lang)]
+        if not definitions:
+            return None
+        formatted = [self.format_definition(d, lang) for d in definitions]
+        return "\n".join(f for f in formatted if f)
+
+    # ---- non-plural --------------------------------------------------------
+
+    def key_value_pattern(self) -> str:
+        return '<message id="%(key)s">%(comment)s\n<source>%(source)s</source>\n<translation>%(value)s</translation>\n</message>'
+
+    def format_key_value(self, definition: TwineDefinition, lang: str) -> Optional[str]:
+        value = definition.translation_for_lang(lang)
+        if value is None:
+            return None
+        return self.key_value_pattern() % {
+            "key": self._escape(definition.key),
+            "comment": self._format_extracomment(definition),
+            "source": self._format_source(definition),
+            "value": self.format_value(value),
+        }
+
+    def _format_extracomment(self, definition: TwineDefinition) -> str:
+        """Twine 'comment' → Qt <extracomment> (translator-facing context).
+        Empty string when no comment is present so the format pattern keeps
+        a clean structure with no blank lines."""
+        comment = definition.comment
+        if not comment:
+            return ""
+        return f"\n<extracomment>{self._escape(comment)}</extracomment>"
+
+    def _format_source(self, definition: TwineDefinition) -> str:
+        """<source> is the developer-language string with placeholders mapped
+        to Qt %1/%2 form. Falls back to the key if no developer translation
+        exists. Reads from the original (unprocessed) twine_file since the
+        OutputProcessor strips non-target translations from the copy."""
+        default_lang = self.twine_file.get_developer_language_code()
+        original = self.twine_file.definitions_by_key.get(definition.key, definition)
+        value = original.translation_for_lang(default_lang) if default_lang else None
+        return self.format_value(value if value is not None else definition.key)
+
+    # ---- plural ------------------------------------------------------------
+
+    def format_plural(self, definition: TwineDefinition, lang: str) -> Optional[str]:
+        forms = get_qt_numerus_forms(lang)
+        if forms is None:
+            raise TwineError(
+                f"Qt has no plural rule for language '{lang}' "
+                f"(key '{definition.key}'). Add it to qt_plural_rules.py."
+            )
+
+        # Always read from the original twine_file — the processed definition
+        # only carries target-lang plurals (after the OutputProcessor may have
+        # filled the slot from a fallback language). We need both target and
+        # developer forms for the per-form fallback chain.
+        original = self.twine_file.definitions_by_key.get(definition.key, definition)
+        translated = original.plural_translation_for_lang(lang) or {}
+        fallback = self._developer_plural_forms(original)
+
+        numerusforms: List[str] = []
+        for category in forms:
+            raw = self._pick_plural_value(definition.key, lang, category, translated, fallback)
+            converted = self._convert_plural_value(raw)
+            numerusforms.append(
+                f"<numerusform>{self._escape_boundary_spaces(self._escape(converted))}</numerusform>"
+            )
+
+        source = self._format_plural_source(definition)
+        extracomment = self._format_extracomment(definition)
+        return (
+            f'<message id="{self._escape(definition.key)}" numerus="yes">{extracomment}\n'
+            f'<source>{source}</source>\n'
+            f'<translation>\n' + "\n".join(numerusforms) + "\n</translation>\n"
+            '</message>'
+        )
+
+    def format_plural_keys(self, key: str, plural_hash: Dict[str, str]) -> str:
+        # Not used — format_plural() is overridden directly to access the
+        # full definition (needed for the developer-language fallback).
+        raise NotImplementedError
+
+    def _developer_plural_forms(self, definition: TwineDefinition) -> Dict[str, str]:
+        default_lang = self.twine_file.get_developer_language_code()
+        if not default_lang:
+            return {}
+        return definition.plural_translation_for_lang(default_lang) or {}
+
+    def _pick_plural_value(self, key: str, lang: str, category: str,
+                            translated: Dict[str, str],
+                            fallback: Dict[str, str]) -> str:
+        """Per-form fallback chain:
+          1. translated[category]
+          2. translated['other']
+          3. fallback (developer-language) [category]
+          4. fallback (developer-language) ['other']
+          Fails with a clear error if all four are missing.
+        """
+        for source in (translated, fallback):
+            if category in source:
+                return source[category]
+            if "other" in source:
+                return source["other"]
+        raise TwineError(
+            f"Cannot resolve plural form '{category}' for key '{key}' in "
+            f"language '{lang}': neither translated nor developer-language "
+            f"forms contain a usable fallback."
+        )
+
+    def _format_plural_source(self, definition: TwineDefinition) -> str:
+        """Pick a representative source string for the plural — used by Qt
+        Linguist as the displayed source text. Prefer developer-language
+        'other', fall back through other CLDR categories, then through any
+        other language. Reads from the original twine_file to access dev-lang
+        forms."""
+        original = self.twine_file.definitions_by_key.get(definition.key, definition)
+        candidates = [self._developer_plural_forms(original)]
+        candidates.extend(original.plural_translations.values())
+        for plural in candidates:
+            for category in _SOURCE_PLURAL_PREFERENCE:
+                if category in plural:
+                    return self._convert_plural_value_for_source(plural[category])
+        return self._escape(definition.key)
+
+    def _convert_plural_value_for_source(self, value: str) -> str:
+        return self._escape_boundary_spaces(self._escape(self._convert_plural_value(value)))
+
+    # ---- value formatting --------------------------------------------------
+
+    def format_value(self, value: str) -> str:
+        """Non-plural value: sequential %@/%d → %1, %2, …; preserve numbered
+        forms; restore real newlines; escape XML and boundary spaces."""
+        converted = self._convert_placeholders_sequential(value).replace("\\n", "\n")
+        return self._escape_boundary_spaces(self._escape(converted))
+
+    def _convert_plural_value(self, value: str) -> str:
+        """Plural value: first count-eligible placeholder becomes %n; the
+        rest are numbered sequentially starting from %1."""
+        return self._convert_placeholders_plural(value).replace("\\n", "\n")
+
+    @staticmethod
+    def _convert_placeholders_sequential(value: str) -> str:
+        """Twine/Apple placeholders → Qt positional. `%N$x` is preserved as
+        `%N` (already numbered); unnumbered placeholders are assigned
+        sequentially from 1."""
+        next_index = 1
+
+        def replace(match: re.Match) -> str:
+            nonlocal next_index
+            placeholder = match.group(0)
+            numbered = re.match(r"%(\d+)\$", placeholder)
+            if numbered:
+                return f"%{numbered.group(1)}"
+            result = f"%{next_index}"
+            next_index += 1
+            return result
+
+        return PLACEHOLDER_REGEX.sub(replace, value)
+
+    @staticmethod
+    def _convert_placeholders_plural(value: str) -> str:
+        """Like _convert_placeholders_sequential, but the first
+        count-eligible placeholder (numeric type) becomes %n."""
+        n_assigned = False
+        next_index = 1
+
+        def is_count_eligible(placeholder: str) -> bool:
+            return placeholder[-1] in _NUMERIC_TYPES
+
+        def replace(match: re.Match) -> str:
+            nonlocal n_assigned, next_index
+            placeholder = match.group(0)
+            numbered = re.match(r"%(\d+)\$", placeholder)
+
+            if not n_assigned and is_count_eligible(placeholder):
+                n_assigned = True
+                return "%n"
+
+            if numbered:
+                return f"%{numbered.group(1)}"
+            result = f"%{next_index}"
+            next_index += 1
+            return result
+
+        return PLACEHOLDER_REGEX.sub(replace, value)
+
+    # ---- escaping / helpers ------------------------------------------------
+
+    @staticmethod
+    def _unformat_value(value: str) -> str:
+        """Inverse of inserting real newlines: collapse '\\n' back for the
+        Twine in-memory representation."""
+        return value.replace("\n", "\\n")
+
+    @staticmethod
+    def _escape(value: str) -> str:
+        return html.escape(value, quote=True)
+
+    @staticmethod
+    def _escape_boundary_spaces(value: str) -> str:
+        """Qt strips leading/trailing whitespace inside <translation> and
+        <numerusform>; replace any boundary whitespace character (space,
+        tab, NBSP, …) with its numeric entity per line so it survives
+        lrelease."""
+        def to_entities(s: str) -> str:
+            return "".join(f"&#{ord(c)};" for c in s)
+
+        def escape_line(line: str) -> str:
+            if not line:
+                return line
+            stripped = line.strip()
+            if not stripped:
+                return to_entities(line)
+            leading = len(line) - len(line.lstrip())
+            trailing_end = len(line) - (len(line) - len(line.rstrip()))
+            return to_entities(line[:leading]) + line[leading:trailing_end] + to_entities(line[trailing_end:])
+
+        return "\n".join(escape_line(line) for line in value.split("\n"))

--- a/python_twine/twine/formatters/qt_plural_rules.py
+++ b/python_twine/twine/formatters/qt_plural_rules.py
@@ -1,0 +1,267 @@
+"""
+Qt plural-rule table for the qt formatter.
+
+Maps a two- or three-letter language code (with optional region) to the
+positional list of CLDR plural categories that Qt's lrelease/QTranslator
+expects in <numerusform> entries.
+
+The table is derived from Qt's source at
+qttools/src/linguist/shared/numerus.cpp (numerusTable[]). When generating
+a Qt TS file for a language, the formatter emits one <numerusform> per
+entry in QT_NUMERUS_FORMS[lang], in order.
+"""
+
+from typing import Dict, List, Optional
+
+
+# 1 form: Universal (lookup returns "other")
+_JAPANESE_STYLE: List[str] = ["other"]
+
+# 2 forms: n != 1 → other
+_ENGLISH_STYLE: List[str] = ["one", "other"]
+
+# 2 forms: n <= 1 → one. Same positional shape as english style.
+_FRENCH_STYLE: List[str] = ["one", "other"]
+
+# 2 forms: n%10==1 && n%100!=11 → one, else other.
+_ICELANDIC: List[str] = ["one", "other"]
+
+# 3 forms: one, other, zero. Note: Qt's positional order puts zero last.
+_LATVIAN: List[str] = ["one", "other", "zero"]
+
+# 3 forms: n==1, n==2, else.
+_IRISH_STYLE: List[str] = ["one", "two", "other"]
+
+# 4 forms: 1/11, 2/12, 3-19, else.
+_GAELIC_STYLE: List[str] = ["one", "two", "few", "other"]
+
+# 3 forms: 1, 2-4, else.
+_SLOVAK_STYLE: List[str] = ["one", "few", "other"]
+
+# 3 forms: %100==1, %100==2, else.
+_MACEDONIAN: List[str] = ["one", "two", "other"]
+
+# 3 forms: %10==1 & %100!=11; %10!=0 & %100 not in 10-19; else.
+_LITHUANIAN: List[str] = ["one", "few", "many"]
+
+# 3 forms: %10==1 & %100!=11; %10 in 2-4 & %100 not in 10-19; else.
+# Used by ru, uk, be, hr, sr, bs.
+_RUSSIAN_STYLE: List[str] = ["one", "few", "many"]
+
+# 3 forms: 1; %10 in 2-4 & %100 not in 10-19; else.
+_POLISH: List[str] = ["one", "few", "many"]
+
+# 3 forms: 1; 0 or %100 in 1-19; else.
+_ROMANIAN: List[str] = ["one", "few", "other"]
+
+# 4 forms: %100==1; %100==2; %100 in 3-4; else.
+_SLOVENIAN: List[str] = ["one", "two", "few", "other"]
+
+# 4 forms: 1; 0 or %100 in 1-10; %100 in 11-19; else.
+_MALTESE: List[str] = ["one", "few", "many", "other"]
+
+# 5 forms: 0; 1; 2-5; 6; else.
+_WELSH: List[str] = ["zero", "one", "two", "few", "other"]
+
+# 6 forms: 0; 1; 2; %100 in 3-10; %100 >= 11; else.
+_ARABIC: List[str] = ["zero", "one", "two", "few", "many", "other"]
+
+
+# Map from CLDR/ISO language code → positional CLDR-category list.
+# Region-specific overrides go through region-aware lookup below.
+QT_NUMERUS_FORMS: Dict[str, List[str]] = {
+    # japaneseStyle
+    "bi": _JAPANESE_STYLE,
+    "my": _JAPANESE_STYLE,
+    "zh": _JAPANESE_STYLE,
+    "zh-Hans": _JAPANESE_STYLE,
+    "zh-Hant": _JAPANESE_STYLE,
+    "dz": _JAPANESE_STYLE,
+    "fj": _JAPANESE_STYLE,
+    "gn": _JAPANESE_STYLE,
+    "hu": _JAPANESE_STYLE,
+    "id": _JAPANESE_STYLE,
+    "ja": _JAPANESE_STYLE,
+    "jv": _JAPANESE_STYLE,
+    "ko": _JAPANESE_STYLE,
+    "ms": _JAPANESE_STYLE,
+    "na": _JAPANESE_STYLE,
+    "om": _JAPANESE_STYLE,
+    "fa": _JAPANESE_STYLE,
+    "su": _JAPANESE_STYLE,
+    "tt": _JAPANESE_STYLE,
+    "th": _JAPANESE_STYLE,
+    "bo": _JAPANESE_STYLE,
+    "tr": _JAPANESE_STYLE,
+    "vi": _JAPANESE_STYLE,
+    "yo": _JAPANESE_STYLE,
+    "za": _JAPANESE_STYLE,
+
+    # englishStyle
+    "ab": _ENGLISH_STYLE,
+    "aa": _ENGLISH_STYLE,
+    "af": _ENGLISH_STYLE,
+    # Asturian (ast) is not in Qt's numerusTable, but CLDR places it in the
+    # english-style 2-form group (one = n==1, other = else).
+    "ast": _ENGLISH_STYLE,
+    "sq": _ENGLISH_STYLE,
+    "am": _ENGLISH_STYLE,
+    "as": _ENGLISH_STYLE,
+    "ay": _ENGLISH_STYLE,
+    "az": _ENGLISH_STYLE,
+    "ba": _ENGLISH_STYLE,
+    "eu": _ENGLISH_STYLE,
+    "bn": _ENGLISH_STYLE,
+    "bg": _ENGLISH_STYLE,
+    "ca": _ENGLISH_STYLE,
+    "kw": _ENGLISH_STYLE,
+    "co": _ENGLISH_STYLE,
+    "da": _ENGLISH_STYLE,
+    "nl": _ENGLISH_STYLE,
+    "en": _ENGLISH_STYLE,
+    "eo": _ENGLISH_STYLE,
+    "et": _ENGLISH_STYLE,
+    "fo": _ENGLISH_STYLE,
+    "fi": _ENGLISH_STYLE,
+    "fur": _ENGLISH_STYLE,
+    "fy": _ENGLISH_STYLE,
+    "gl": _ENGLISH_STYLE,
+    "lg": _ENGLISH_STYLE,
+    "ka": _ENGLISH_STYLE,
+    "de": _ENGLISH_STYLE,
+    "el": _ENGLISH_STYLE,
+    "kl": _ENGLISH_STYLE,
+    "gu": _ENGLISH_STYLE,
+    "ha": _ENGLISH_STYLE,
+    "he": _ENGLISH_STYLE,
+    "hi": _ENGLISH_STYLE,
+    "ia": _ENGLISH_STYLE,
+    "ie": _ENGLISH_STYLE,
+    "it": _ENGLISH_STYLE,
+    "kn": _ENGLISH_STYLE,
+    "ks": _ENGLISH_STYLE,
+    "kk": _ENGLISH_STYLE,
+    "km": _ENGLISH_STYLE,
+    "rw": _ENGLISH_STYLE,
+    "ky": _ENGLISH_STYLE,
+    "ku": _ENGLISH_STYLE,
+    "lo": _ENGLISH_STYLE,
+    "la": _ENGLISH_STYLE,
+    "ln": _ENGLISH_STYLE,
+    "lb": _ENGLISH_STYLE,
+    "mg": _ENGLISH_STYLE,
+    "ml": _ENGLISH_STYLE,
+    "mr": _ENGLISH_STYLE,
+    "mn": _ENGLISH_STYLE,
+    "ne": _ENGLISH_STYLE,
+    "nso": _ENGLISH_STYLE,
+    "nb": _ENGLISH_STYLE,
+    "nn": _ENGLISH_STYLE,
+    "oc": _ENGLISH_STYLE,
+    "or": _ENGLISH_STYLE,
+    "ps": _ENGLISH_STYLE,
+    # "pt" (default Portugal) is englishStyle; "pt-BR" is overridden below.
+    "pt": _ENGLISH_STYLE,
+    "pa": _ENGLISH_STYLE,
+    "qu": _ENGLISH_STYLE,
+    "rm": _ENGLISH_STYLE,
+    "rn": _ENGLISH_STYLE,
+    "sn": _ENGLISH_STYLE,
+    "sd": _ENGLISH_STYLE,
+    "si": _ENGLISH_STYLE,
+    "so": _ENGLISH_STYLE,
+    "st": _ENGLISH_STYLE,
+    "es": _ENGLISH_STYLE,
+    "sw": _ENGLISH_STYLE,
+    "ss": _ENGLISH_STYLE,
+    "sv": _ENGLISH_STYLE,
+    "tg": _ENGLISH_STYLE,
+    "ta": _ENGLISH_STYLE,
+    "te": _ENGLISH_STYLE,
+    "to": _ENGLISH_STYLE,
+    "ts": _ENGLISH_STYLE,
+    "tn": _ENGLISH_STYLE,
+    "tk": _ENGLISH_STYLE,
+    "ug": _ENGLISH_STYLE,
+    "ur": _ENGLISH_STYLE,
+    "uz": _ENGLISH_STYLE,
+    "vo": _ENGLISH_STYLE,
+    "wo": _ENGLISH_STYLE,
+    "xh": _ENGLISH_STYLE,
+    "yi": _ENGLISH_STYLE,
+    "zu": _ENGLISH_STYLE,
+
+    # frenchStyle (Qt rule: n <= 1 → one).
+    "hy": _FRENCH_STYLE,
+    "br": _FRENCH_STYLE,
+    "fr": _FRENCH_STYLE,
+    "fil": _FRENCH_STYLE,
+    "ti": _FRENCH_STYLE,
+    "wa": _FRENCH_STYLE,
+    # pt-BR overrides the "pt" → englishStyle entry above.
+    "pt-BR": _FRENCH_STYLE,
+
+    # irishStyle
+    "dv": _IRISH_STYLE,
+    "iu": _IRISH_STYLE,
+    "ik": _IRISH_STYLE,
+    "ga": _IRISH_STYLE,
+    "gv": _IRISH_STYLE,
+    "mi": _IRISH_STYLE,
+    "se": _IRISH_STYLE,
+    "sm": _IRISH_STYLE,
+    "sa": _IRISH_STYLE,
+
+    # russianStyle
+    "bs": _RUSSIAN_STYLE,
+    "be": _RUSSIAN_STYLE,
+    "hr": _RUSSIAN_STYLE,
+    "ru": _RUSSIAN_STYLE,
+    "sr": _RUSSIAN_STYLE,
+    "uk": _RUSSIAN_STYLE,
+
+    # slovakStyle
+    "sk": _SLOVAK_STYLE,
+    "cs": _SLOVAK_STYLE,
+
+    # standalone groups
+    "ar": _ARABIC,
+    "cy": _WELSH,
+    "is": _ICELANDIC,
+    "lv": _LATVIAN,
+    "lt": _LITHUANIAN,
+    "mk": _MACEDONIAN,
+    "mt": _MALTESE,
+    "pl": _POLISH,
+    "ro": _ROMANIAN,
+    "sl": _SLOVENIAN,
+    "gd": _GAELIC_STYLE,
+}
+
+
+def _base_language(lang: str) -> str:
+    """Strip region tag: 'es-MX' → 'es', 'zh-Hans' → 'zh-Hans' (unchanged)."""
+    # zh-Hans / zh-Hant are first-class entries; only strip plain region tags.
+    if lang in QT_NUMERUS_FORMS:
+        return lang
+    if "-" in lang:
+        return lang.split("-", 1)[0]
+    return lang
+
+
+def get_qt_numerus_forms(lang: str) -> Optional[List[str]]:
+    """
+    Return positional CLDR-category list for `lang`, or None if Qt has no
+    plural rule for this language.
+
+    Lookup order:
+      1. Exact match (e.g., 'pt-BR', 'zh-Hans').
+      2. Base-language fallback (e.g., 'es-MX' → 'es').
+    """
+    forms = QT_NUMERUS_FORMS.get(lang)
+    if forms is not None:
+        return forms
+    base = _base_language(lang)
+    if base != lang:
+        return QT_NUMERUS_FORMS.get(base)
+    return None

--- a/python_twine/twine/formatters/registry.py
+++ b/python_twine/twine/formatters/registry.py
@@ -69,6 +69,7 @@ def register_all_formatters():
     from twine.formatters.flash import FlashFormatter
     from twine.formatters.gettext import GettextFormatter
     from twine.formatters.jquery import JQueryFormatter
+    from twine.formatters.qt import QtFormatter
     from twine.formatters.tizen import TizenFormatter
 
     registry = get_registry()
@@ -81,6 +82,7 @@ def register_all_formatters():
     registry.register(FlashFormatter())
     registry.register(GettextFormatter())
     registry.register(JQueryFormatter())
+    registry.register(QtFormatter())
     registry.register(TizenFormatter())
 
 

--- a/python_twine/twine/output_processor.py
+++ b/python_twine/twine/output_processor.py
@@ -118,10 +118,16 @@ class OutputProcessor:
                     if language not in new_definition.plural_translations \
                             and include_option != "translated":
                         lng = definition.find_plural_lang_fallback(fallbacks)
-                        new_definition.plural_translations[language] = definition.plural_translation_for_lang(lng)
+                        if lng is not None:
+                            new_definition.plural_translations[language] = definition.plural_translation_for_lang(lng)
 
-                    # Ensure 'other' key exists for plurals
-                    if "other" not in new_definition.plural_translations[language]:
+                    # Ensure 'other' key exists for plurals. Skip when no
+                    # plural slot exists for the target language (e.g.
+                    # include=translated and only a non-plural translation
+                    # is present) — the definition falls through to the
+                    # non-plural path in the formatter.
+                    if language in new_definition.plural_translations \
+                            and "other" not in new_definition.plural_translations[language]:
                         new_definition.plural_translations[language]["other"] = value
 
                 new_section.definitions.append(new_definition)


### PR DESCRIPTION
## Summary

Adds a first-class `qt` formatter that emits Qt Linguist TS files (consumed by `lrelease` → QM bundles, looked up at runtime via `qtTrId`).

- **Output**: ID-based `<message id="...">` in a single empty `<context><name></name>` (required by `qtTrId`); definition comments emitted as `<extracomment>`; sequential `%@`/`%d` → `%1`,`%2` placeholder conversion with numbered `%N$x` preserved; leading/trailing whitespace on each line (space, tab, NBSP, …) escaped as numeric entities so it survives `lrelease`.
- **Plurals**: Twine's CLDR-named categories → Qt's positional `<numerusform>` via a table derived from `qttools/src/linguist/shared/numerus.cpp`. Per-form fallback chain `translated[cat] → translated[other] → developer[cat] → developer[other]`. Region tags fall back to base language; `pt-BR`, `zh-Hans`/`zh-Hant`, `ast` get explicit entries.
- **Read** support covers non-plural messages; numerus forms are skipped (positional → CLDR is lossy, no current pipeline needs it).
- Fixes a pre-existing crash in `OutputProcessor.process()` where a plural definition whose target language had only a non-plural translation (or no fallback language with plural data) raised `KeyError`/`TypeError`.

## Test plan

- [x] `pytest python_twine/tests` — 132 passing (was 119; +13 new tests covering formatter singular/plural paths, fallback chain, escaping, extracomment, `OutputProcessor` regression, and lrelease integration).
- [x] Regenerated all 63 OM language files from `data/strings/strings.txt`; every file compiles cleanly through `lrelease` with no warnings or errors.
- [x] Spot-checked plural keys (`bookmarks_places`, `tracks`, `bookmarks_detect_message`) — now emit correct positional `<numerusform>` per language instead of being silently rendered as their `other` form.
- [x] Verified `<extracomment>` placement matches Qt Linguist's expectations (between `<message ...>` and `<source>`).

LLM tooling was used to draft and refine portions of this change.

CC @osyotr