### PR TITLE
Classify localization folders by name, not by the whole path

### DIFF
--- a/lib/twine/formatters/abstract.rb
+++ b/lib/twine/formatters/abstract.rb
@@ -87,6 +87,15 @@ module Twine
         path.split(File::SEPARATOR).reverse.find { |segment| segment =~ only_language_and_region }
       end
 
+      # Language of a localization folder, or nil if it is not one.
+      # Only the folder's own name is considered. determine_language_given_path
+      # classifies a whole path and scans every segment, which is right for a file
+      # the user named but wrong here: an unrelated ancestor such as /tmp or /opt
+      # matches the language regex and turns every folder into a language.
+      def language_for_folder_name(name)
+        determine_language_given_path(name)
+      end
+
       def output_path_for_language(lang)
         lang
       end

--- a/lib/twine/formatters/android.rb
+++ b/lib/twine/formatters/android.rb
@@ -54,6 +54,11 @@ module Twine
         return super
       end
 
+      def language_for_folder_name(name)
+        return nil unless name == 'values' || name.start_with?('values-')
+        determine_language_given_path(name)
+      end
+
       def output_path_for_language(lang)
         if lang == @twine_file.language_codes[0]
           "values"

--- a/lib/twine/formatters/apple.rb
+++ b/lib/twine/formatters/apple.rb
@@ -35,6 +35,11 @@ module Twine
         return super
       end
 
+      def language_for_folder_name(name)
+        return nil unless name.end_with?('.lproj')
+        determine_language_given_path(name)
+      end
+
       def output_path_for_language(lang)
         "#{lang}.lproj"
       end

--- a/lib/twine/runner.rb
+++ b/lib/twine/runner.rb
@@ -115,7 +115,7 @@ module Twine
           output_path = File.join(@options[:output_path], item)
           next unless File.directory?(output_path)
 
-          lang = formatter.determine_language_given_path(output_path)
+          lang = formatter.language_for_folder_name(item)
           next unless lang
 
           language_found = true

--- a/python_twine/tests/test_integration.py
+++ b/python_twine/tests/test_integration.py
@@ -6,6 +6,7 @@ import tempfile
 from pathlib import Path
 
 from twine.formatters.registry import get_registry
+from twine.runner import Runner
 from twine.twine_file import TwineFile
 
 
@@ -81,6 +82,123 @@ def test_complete_workflow():
         print("✓ jQuery formatter works")
 
         print("\n✅ All integration tests passed!")
+
+
+def test_generate_all_skips_non_language_folders():
+    """Only language folders get files, whatever the output path's ancestors look like.
+
+    Regression test: the classifier used to be handed the whole path, so a short
+    lowercase ancestor (/tmp, /var, /opt, /home/ab) matched the language regex and
+    every non-language subfolder was written to as if it were a language.
+    """
+    twine_content = """[[General]]
+\t[hello]
+\t\ten = Hello
+\t\tde = Hallo
+"""
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        twine_file_path = temp_path / "strings.txt"
+        twine_file_path.write_text(twine_content)
+
+        twine_file = TwineFile()
+        twine_file.read(str(twine_file_path))
+
+        output_path = temp_path / "out"
+        for folder in ("en.lproj", "de.lproj", "Views", "ChartData", "raw", "xml"):
+            (output_path / folder).mkdir(parents=True)
+
+        runner = Runner(
+            options={
+                "output_path": str(output_path),
+                "format": "apple",
+                # English fallback, so a bogus language would still produce a file.
+                "include": "all",
+            },
+            twine_file=twine_file,
+        )
+        runner.generate_all_localization_files()
+
+        for folder in ("en.lproj", "de.lproj"):
+            assert (output_path / folder / "Localizable.strings").is_file()
+
+        for folder in ("Views", "ChartData", "raw", "xml"):
+            assert not (output_path / folder / "Localizable.strings").exists()
+
+
+def test_generate_all_skips_non_language_folders_without_a_convention():
+    """The folder name alone decides, for formatters with no fixed folder shape.
+
+    gettext has no .lproj/values marker, so this is what actually exercises the
+    runner: handed the full path, the temp directory's own ancestors match the
+    language regex and every folder becomes a language.
+    """
+    twine_content = """[[General]]
+\t[hello]
+\t\ten = Hello
+\t\tde = Hallo
+"""
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        twine_file_path = temp_path / "strings.txt"
+        twine_file_path.write_text(twine_content)
+
+        twine_file = TwineFile()
+        twine_file.read(str(twine_file_path))
+
+        output_path = temp_path / "out"
+        for folder in ("en", "de", "Views"):
+            (output_path / folder).mkdir(parents=True)
+
+        runner = Runner(
+            options={
+                "output_path": str(output_path),
+                "format": "gettext",
+                "include": "all",
+            },
+            twine_file=twine_file,
+        )
+        runner.generate_all_localization_files()
+
+        for folder in ("en", "de"):
+            assert (output_path / folder / "strings.po").is_file()
+
+        assert not (output_path / "Views" / "strings.po").exists()
+
+
+def test_folder_classification_is_stricter_than_path_classification():
+    """Folder scanning is strict; naming a file directly still resolves its language.
+
+    determine_language_given_path() is also reached from _prepare_read_write(), where
+    a missing language silently falls back to the developer language — so tightening
+    it there would make `consume-localization-file de.strings` import German as English.
+    """
+    for fmt, folders in (
+        ("apple", ("Views", "ChartData", "raw", "xml")),
+        ("android", ("raw", "xml", "drawable", "anim", "font")),
+    ):
+        formatter = get_registry().get(fmt)
+        formatter.twine_file = TwineFile()
+        formatter.options = {}
+
+        for folder in folders:
+            assert formatter.language_for_folder_name(folder) is None
+
+    apple = get_registry().get("apple")
+    apple.twine_file = TwineFile()
+    apple.options = {}
+    assert apple.language_for_folder_name("de.lproj") == "de"
+    assert apple.determine_language_given_path("de.strings") == "de"
+
+    android = get_registry().get("android")
+    android.twine_file = TwineFile()
+    android.options = {}
+    assert android.language_for_folder_name("values-fi") == "fi"
+    assert android.determine_language_given_path("de.xml") == "de"
 
 
 if __name__ == "__main__":

--- a/python_twine/twine/formatters/__init__.py
+++ b/python_twine/twine/formatters/__init__.py
@@ -230,6 +230,16 @@ class AbstractFormatter(ABC):
 
         return None
 
+    def language_for_folder_name(self, name: str) -> str | None:
+        """Language of a localization folder, or None if it is not one.
+
+        Only the folder's own name is considered. determine_language_given_path()
+        classifies a whole path and scans every segment, which is right for a file
+        the user named but wrong here: an unrelated ancestor such as /tmp or /opt
+        matches the language regex and turns every folder into a language.
+        """
+        return self.determine_language_given_path(name)
+
     def output_path_for_language(self, lang: str) -> str:
         """Return the output path component for a language."""
         return lang

--- a/python_twine/twine/formatters/android.py
+++ b/python_twine/twine/formatters/android.py
@@ -99,6 +99,12 @@ class AndroidFormatter(AbstractFormatter):
 
         return super().determine_language_given_path(path)
 
+    def language_for_folder_name(self, name: str) -> str | None:
+        """Language of a values[-lang] folder, or None if it is not one."""
+        if name != "values" and not name.startswith("values-"):
+            return None
+        return self.determine_language_given_path(name)
+
     def output_path_for_language(self, lang: str) -> str:
         """Get Android values folder name for language."""
         if self.twine_file.language_codes and lang == self.twine_file.language_codes[0]:

--- a/python_twine/twine/formatters/apple.py
+++ b/python_twine/twine/formatters/apple.py
@@ -49,6 +49,12 @@ class AppleFormatter(AbstractFormatter):
 
         return super().determine_language_given_path(path)
 
+    def language_for_folder_name(self, name: str) -> str | None:
+        """Language of an <lang>.lproj folder, or None if it is not one."""
+        if not name.endswith(".lproj"):
+            return None
+        return self.determine_language_given_path(name)
+
     def output_path_for_language(self, lang: str) -> str:
         """Get .lproj folder name for language."""
         return f"{lang}.lproj"

--- a/python_twine/twine/runner.py
+++ b/python_twine/twine/runner.py
@@ -153,7 +153,7 @@ class Runner:
                 if not item.is_dir():
                     continue
 
-                lang = formatter.determine_language_given_path(str(item))
+                lang = formatter.language_for_folder_name(item.name)
                 if not lang:
                     continue
 
@@ -266,7 +266,7 @@ class Runner:
             if not item.is_dir():
                 continue
 
-            lang = formatter.determine_language_given_path(str(item))
+            lang = formatter.language_for_folder_name(item.name)
             if not lang:
                 continue
 


### PR DESCRIPTION
`determine_language_given_path()` falls back to scanning **every segment** of the path it is given for `^[a-z]{2,3}(-[A-Za-z]{2,4})?$`, and `generate_all_localization_files()` handed it the joined absolute path of each candidate folder. Any short lowercase ancestor of the checkout matches:

```
/private/tmp/omim/iphone/Chart/Chart/ChartData   -> "tmp"   misfire
/home/ab/omim/iphone/Chart/Chart/Views           -> "ab"    misfire
/opt/build/omim/data/sound-strings/en_GB.json    -> "opt"   misfire
/Users/alex/Developer/omim/…                     -> None    ok
```

So every non-language subfolder of an output directory was treated as a language. With `--include all` that wrote full English files into source folders; with `--include translated` the output was empty and silently skipped, which only hid the same misclassification. Worst of all, generated output depended on where the repository happened to be cloned.

Both `generate_all_localization_files()` and `find_translation_files()` iterate the direct children of a single directory, so the language can only come from the child's own name — ancestors are meaningless there. Pass the name instead. `_prepare_read_write()` is left alone: it receives an arbitrary file path such as `…/en.lproj/Localizable.strings`, where the segment walk is the point.

That alone still left folders named `raw` and `xml` matching. Formatters with a fixed convention now return `None` rather than falling back to the generic regex: an Apple localization folder is always `<lang>.lproj`, an Android one always `values[-lang]`.

The same flaw is in `lib/twine/runner.rb`; changed there too for parity.

## Testing

Running organicmaps' `tools/unix/generate_localizations.sh` from a checkout under `/private/tmp`, against a clean tree:

| | before | after |
|---|---|---|
| working tree after generation | 1 file overwritten, 2 bogus files created | clean |
| files generated | 675 | 672 |
| "would not contain any translations" skips | 68 | 6 (all genuine) |

The 672 legitimate files are byte-identical to what is checked in, and a second run is idempotent.

`pytest`: 134 passed, including two new regression tests. One drives the runner through a `TemporaryDirectory`, which reproduces the original bug naturally — macOS temp dirs live under `/var/folders`.
